### PR TITLE
Prepare structure for the parser

### DIFF
--- a/src/Lexer.zig
+++ b/src/Lexer.zig
@@ -126,7 +126,7 @@ fn reportError(self: *Self, code: []const u8, message: []const u8, error_type: S
         .labels = &.{
             reportz.reports.Label{
                 .color = .{ .basic = .magenta },
-                .message = "During scanning of this token",
+                .message = "During scanning of this token.",
                 .span = .{ .start = self.start, .end = self.current },
             },
         },

--- a/src/common.zig
+++ b/src/common.zig
@@ -1,3 +1,5 @@
+const std = @import("std");
+
 // Span stores indices of where given token or node starts and ends.
 pub const Span = struct {
     start: usize,
@@ -9,3 +11,100 @@ pub const Span = struct {
         return span.end - span.start;
     }
 };
+
+// Template for trees. This is used by both AST and IR as their only difference is node set.
+pub fn Tree(comptime Node: type) type {
+    return struct {
+        arena: std.heap.ArenaAllocator,
+        nodes: std.ArrayList(Node),
+
+        const Self = @This();
+        pub fn init(alloc: std.mem.Allocator) Self {
+            return Self{
+                .arena = .init(alloc),
+                .nodes = .init(alloc),
+            };
+        }
+
+        pub fn deinit(self: *Self) void {
+            self.nodes.deinit();
+            self.arena.deinit();
+        }
+
+        // Just a pretty way of getting arena allocator.
+        // This is the same as calling `tree.arena.allocator()`.
+        pub inline fn allocator(self: *Self) std.mem.Allocator {
+            return self.arena.allocator();
+        }
+
+        // Appends new node to this tree returning its ID.
+        pub fn addNode(self: *Self, node: Node) std.mem.Allocator.Error!usize {
+            const old_len = self.nodes.items.len;
+            try self.nodes.append(node);
+            return old_len;
+        }
+
+        // Gets node from the tree. If node does not exists this returns null.
+        pub fn getNode(self: *Self, id: usize) ?Node {
+            if (self.nodes.items.len > id)
+                return self.nodes.items[id];
+            return null;
+        }
+
+        // Gets node from the tree with an assumption that it exists.
+        // Avoid calling this, as it may cause segmentation faults.
+        pub inline fn getNodeUnsafe(self: *Self, id: usize) Node {
+            return self.nodes.items[id];
+        }
+    };
+}
+
+// Utility function to deeply copy a structure.
+pub fn deepClone(comptime T: type, value: T, allocator: std.mem.Allocator) !T {
+    return try cloneInner(T, value, allocator);
+}
+
+fn cloneInner(comptime T: type, value: T, allocator: std.mem.Allocator) !T {
+    const info = @typeInfo(T);
+
+    return switch (info) {
+        .Struct => blk: {
+            var result: T = undefined;
+
+            inline for (std.meta.fields(T)) |field| {
+                const field_val = @field(value, field.name);
+                const cloned_val = try cloneInner(field.field_type, field_val, allocator);
+                @field(result, field.name) = cloned_val;
+            }
+
+            break :blk result;
+        },
+
+        .Pointer => |ptr_info| switch (ptr_info.size) {
+            .Slice => blk: {
+                const len = value.len;
+                const buf = try allocator.alloc(ptr_info.child, len);
+                std.mem.copy(ptr_info.child, buf, value);
+                break :blk buf;
+            },
+
+            .One => blk: {
+                const ptr = try allocator.create(ptr_info.child);
+                ptr.* = try cloneInner(ptr_info.child, value.*, allocator);
+                break :blk ptr;
+            },
+
+            else => return error.UnsupportedPointerType,
+        },
+
+        .Array => blk: {
+            var arr: T = undefined;
+            for (value, 0..) |elem, i| {
+                arr[i] = try cloneInner(@TypeOf(elem), elem, allocator);
+            }
+            break :blk arr;
+        },
+
+        else => value, // Copy scalars, enums, etc. directly
+    };
+}

--- a/src/parse/Parser.zig
+++ b/src/parse/Parser.zig
@@ -1,0 +1,144 @@
+const std = @import("std");
+
+const reportz = @import("reportz");
+
+const common = @import("../common.zig");
+const Lexer = @import("../Lexer.zig");
+const Token = Lexer.Token;
+const TokenType = Lexer.TokenType;
+const ast = @import("ast.zig");
+
+allocator: std.mem.Allocator,
+tree: ast.Tree,
+
+// Parser references lexer, because it does not allocate,
+// so we parse tokens one by one.
+lexer: *Lexer,
+
+// Diagnostics for logging errors.
+// These are untouched until the error occurs.
+diagnostic_arena: std.heap.ArenaAllocator,
+diagnostic_log: std.ArrayList(reportz.reports.Diagnostic),
+
+// ---< Internal fields begin >---
+cached_token: ?Token = null,
+// ---< Internal fields end >---
+
+const Self = @This();
+const LOG = std.log.scoped(.parser);
+
+pub const Error = error{
+    UnexpectedToken,
+} || Lexer.Error || std.mem.Allocator.Error;
+
+pub fn init(alloc: std.mem.Allocator, lexer: *Lexer) Self {
+    return Self{
+        .allocator = alloc,
+        .tree = .init(alloc),
+        .lexer = lexer,
+        .diagnostic_arena = .init(alloc),
+        .diagnostic_log = .init(alloc),
+    };
+}
+
+pub fn deinit(self: *Self, deinit_tree: bool) void {
+    if (deinit_tree) // We may want to keep the tree for further passes or interpreter.
+        self.tree.deinit();
+    self.diagnostic_log.deinit();
+    self.diagnostic_arena.deinit();
+}
+
+// ---< Helper and utility functions begin >---
+
+// Internal method for reporting error diagnostics.
+// This should be called in place of `error.*` whenever returning any errors.
+// Please examine the code below to get more details on usage before implementing new features.
+fn reportError(
+    self: *Self,
+    code: []const u8,
+    comptime message_fmt: []const u8,
+    message_args: anytype,
+    error_type: Self.Error,
+    additional_options: struct {
+        severity: reportz.reports.Severity = .@"error",
+        labels: []const reportz.reports.Label,
+        notes: []const reportz.reports.Note = &.{},
+    },
+) Self.Error {
+    // This tells the compiler this function is unlikely to be called.
+    @branchHint(.cold);
+
+    const diagnostic_alloc = self.diagnostic_arena.allocator();
+
+    self.diagnostic_log.append(reportz.reports.Diagnostic{
+        .source_id = self.lexer.source_id,
+        .severity = additional_options.severity,
+        .code = code,
+        .message = std.fmt.allocPrint(diagnostic_alloc, message_fmt, message_args),
+        // This ensures that labels and notes live at least as long as diagnostic_log field.
+        .labels = common.deepClone(
+            []const reportz.reports.Label,
+            additional_options.labels,
+            diagnostic_alloc,
+        ),
+        .notes = common.deepClone(
+            []const reportz.reports.Note,
+            additional_options.notes,
+            diagnostic_alloc,
+        ),
+    });
+
+    return error_type;
+}
+
+// Peek at the next token without advancing.
+fn peek(self: *Self) !Token {
+    if (self.cached_token) |cached|
+        return cached;
+    self.cached_token = try self.lexer.next();
+    return self.cached_token.?; // We may do `.?` because we set it above.
+}
+
+// Advance one token forward and return current token.
+fn advance(self: *Self) !Token {
+    const current_token = self.peek();
+    self.cached_token = null;
+    return current_token;
+}
+
+// Advance parser by one token and expect token to be of given type.
+// If token type does not match, this function will return an error.
+// If token type matches, this function will return the token.
+fn expect(self: *Self, expected_type: TokenType) Self.Error!Token {
+    if ((try self.peek()).type == expected_type)
+        return try self.advance()
+    else {
+        @branchHint(.unlikely);
+        const invalid_token = try self.advance();
+        // TODO: Make some kind of map to report expected tokens in a more pretty way.
+        return self.reportError(
+            "P001",
+            "Found invalid token. Expected '{any}' but got '{s}'.",
+            .{ expected_type, invalid_token.lexeme },
+            error.InvalidToken,
+            .{
+                .labels = &.{.{
+                    .color = .{ .basic = .magenta },
+                    .span = .{ .start = invalid_token.span.start, .end = invalid_token.span.end },
+                    .message = "Found this token.",
+                }},
+            },
+        );
+    }
+}
+
+// Works similarly to `expect` method, but instead of panicking
+// if the token does not match it just returns null.
+fn maybe(self: *Self, maybe_type: TokenType) Self.Error!?Token {
+    return if ((try self.peek()).type == maybe_type)
+        try self.advance()
+    else
+        null;
+}
+
+// ---< Helper and utility functions end >---

--- a/src/parse/ast.zig
+++ b/src/parse/ast.zig
@@ -1,0 +1,14 @@
+const common = @import("../common.zig");
+
+// Type alias for AST Tree.
+pub const Tree = common.Tree(Node);
+
+// Main structure for the AST node.
+pub const Node = struct {
+    span: common.Span,
+    kind: NodeKind,
+};
+
+// Kind of AST node.
+// Every kind is different when it comes to what it represents and stores.
+pub const NodeKind = union(enum) {};

--- a/src/root.zig
+++ b/src/root.zig
@@ -4,6 +4,7 @@
 const std = @import("std");
 
 pub const Lexer = @import("Lexer.zig");
+pub const Parser = @import("parse/Parser.zig");
 
 // Above are temporary public imports. Used for testing until there is proper library API.
 


### PR DESCRIPTION
This PR introduces basic structure for the AST and Parser. 
There are no unit tests, because currently implemented functions are basic building blocks of the parser, and they are short, so any potential issues would be caught by other tests.

**Included changes:**
- Structure for AST `Node`,
- Union for any data that the node may contain called `NodeKind`,
- Basic parser structure with a few helper methods,
- One single dot added in a lexer error message.