### PR TITLE
Add GitHub actions workflow for ci and protecting main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+# .github/workflows/ci.yml
+name: Continuous Integration
+
+on:
+  push:
+    branches:
+      - main
+      - development
+  pull_request:
+    branches:
+      - main
+      - development
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Zig
+        uses: goto-bus-stop/setup-zig@v2
+        with:
+          version: 0.14.1
+
+      - name: Run Zig tests
+        run: zig build test

--- a/.github/workflows/protect-main.yml
+++ b/.github/workflows/protect-main.yml
@@ -1,0 +1,19 @@
+# .github/workflows/protect-main.yml
+name: Enforce Development to Main Merge Policy
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  enforce:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check source branch
+        run: |
+          echo "Source branch is: ${{ github.head_ref }}"
+          if [ "${{ github.head_ref }}" != "development" ]; then
+            echo "::error::Only pull requests from 'development' to 'main' are allowed."
+            exit 1
+          fi


### PR DESCRIPTION
### This pull request adds two GitHub Actions workflows:

- **Continuous Integration (ci.yml):**
Runs all Zig unit and integration tests automatically on every push and pull request targeting main and development branches. This ensures that code is always tested before merging.

- **Branch Protection (protect.yml):**
Enforces that merges into main are only allowed from the development branch, preventing direct commits or merges from other sources.

These workflows improve code stability and enforce a clear development flow.

⚠️ **Note:**
Until this branch is merged into `main`, the workflow will not protect `main` from failing tests and merges from outside of `development`. Currently, the workflow only applies to the branches where it is present (`development` and below).