### PR TITLE
Begin writing parser for statements and modules

### DIFF
--- a/src/common.zig
+++ b/src/common.zig
@@ -1,5 +1,7 @@
 const std = @import("std");
 
+const reportz = @import("reportz");
+
 // Span stores indices of where given token or node starts and ends.
 pub const Span = struct {
     start: usize,
@@ -9,6 +11,10 @@ pub const Span = struct {
 
     pub fn len(span: Self) usize {
         return span.end - span.start;
+    }
+
+    pub inline fn asReportz(self: Self) reportz.reports.Span {
+        return .{ .start = self.start, .end = self.end };
     }
 };
 

--- a/src/common.zig
+++ b/src/common.zig
@@ -68,7 +68,7 @@ fn cloneInner(comptime T: type, value: T, allocator: std.mem.Allocator) !T {
     const info = @typeInfo(T);
 
     return switch (info) {
-        .Struct => blk: {
+        .@"struct" => blk: {
             var result: T = undefined;
 
             inline for (std.meta.fields(T)) |field| {
@@ -80,15 +80,15 @@ fn cloneInner(comptime T: type, value: T, allocator: std.mem.Allocator) !T {
             break :blk result;
         },
 
-        .Pointer => |ptr_info| switch (ptr_info.size) {
-            .Slice => blk: {
+        .pointer => |ptr_info| switch (ptr_info.size) {
+            .slice => blk: {
                 const len = value.len;
                 const buf = try allocator.alloc(ptr_info.child, len);
-                std.mem.copy(ptr_info.child, buf, value);
+                @memcpy(buf, value);
                 break :blk buf;
             },
 
-            .One => blk: {
+            .one => blk: {
                 const ptr = try allocator.create(ptr_info.child);
                 ptr.* = try cloneInner(ptr_info.child, value.*, allocator);
                 break :blk ptr;
@@ -97,7 +97,7 @@ fn cloneInner(comptime T: type, value: T, allocator: std.mem.Allocator) !T {
             else => return error.UnsupportedPointerType,
         },
 
-        .Array => blk: {
+        .array => blk: {
             var arr: T = undefined;
             for (value, 0..) |elem, i| {
                 arr[i] = try cloneInner(@TypeOf(elem), elem, allocator);

--- a/src/parse/Parser.zig
+++ b/src/parse/Parser.zig
@@ -142,3 +142,10 @@ fn maybe(self: *Self, maybe_type: TokenType) Self.Error!?Token {
 }
 
 // ---< Helper and utility functions end >---
+
+// Parse import statement and return its ID if parsed.
+// For more information please reference `ast.zig -> Import` struct.
+pub fn parseMaybeImportStatement(self: *Self) !?usize {
+    if (try self.maybe(.KW_IMPORT) == null) return; // This may not be an import statement.
+    // TODO: Parse import statements once string literals are implemented
+}

--- a/src/parse/ast.zig
+++ b/src/parse/ast.zig
@@ -34,7 +34,7 @@ pub const NodeId = usize;
 // `import "source.brr" as source;`
 pub const Import = struct {
     source: NodeId,
-    opt_rename: ?NodeId,
+    opt_rename: ?NodeId = null,
 };
 
 // ---< AST Nodes end >---

--- a/src/parse/ast.zig
+++ b/src/parse/ast.zig
@@ -1,3 +1,5 @@
+const std = @import("std");
+
 const common = @import("../common.zig");
 
 // Type alias for AST Tree.
@@ -17,6 +19,9 @@ pub const NodeKind = union(enum) {
     // This is a standard string literal. Template literals will be separate.
     string_literal: []const u8,
 
+    // ---< Special nodes >---
+    module: Module,
+
     // ---< Statement nodes >---
     import: Import,
 
@@ -28,6 +33,13 @@ pub const NodeId = usize;
 // ---< AST Nodes begin >---
 // All AST node structs should be located in this section of code.
 // Non-basic nodes should only ever contain references to other nodes.
+
+// Module statement. This node is special, because it has
+// no corresponding langauge syntax. This is just a wrapper
+// to provide one ID with whole top-level code.
+pub const Module = struct {
+    statements: []const usize,
+};
 
 // Import statement. This is equivalent to one of the examples below:
 // `import "source.brr";`

--- a/src/parse/ast.zig
+++ b/src/parse/ast.zig
@@ -11,4 +11,30 @@ pub const Node = struct {
 
 // Kind of AST node.
 // Every kind is different when it comes to what it represents and stores.
-pub const NodeKind = union(enum) {};
+pub const NodeKind = union(enum) {
+    // ---< Basic nodes >---
+    identifier: []const u8,
+    // This is a standard string literal. Template literals will be separate.
+    string_literal: []const u8,
+
+    // ---< Statement nodes >---
+    import: Import,
+
+    // ---< Expression nodes >---
+};
+
+pub const NodeId = usize;
+
+// ---< AST Nodes begin >---
+// All AST node structs should be located in this section of code.
+// Non-basic nodes should only ever contain references to other nodes.
+
+// Import statement. This is equivalent to one of the examples below:
+// `import "source.brr";`
+// `import "source.brr" as source;`
+pub const Import = struct {
+    source: NodeId,
+    opt_rename: ?NodeId,
+};
+
+// ---< AST Nodes end >---


### PR DESCRIPTION
This PR implements three functions in Parser.zig:
- `parseMaybeImportStatement` which parses import statement if first token is `KW_IMPORT`,
- `parseAnyStatement` which is supposed to parse any possible statement (currently only one is supported),
- `parseWholeSource` which parses whole source file and returns `module` node.

**Important:** This implementation does not support semicolons, as they are still not available in lexer.