### PR TITLE
Write parser and ast nodes for native function decls

### DIFF
--- a/src/Lexer.zig
+++ b/src/Lexer.zig
@@ -130,6 +130,7 @@ pub const TokenType = enum {
     SEMICOLON, //';'
     COLON, // ':'
     DOT, // '.'
+    COMMA, // ','
     RANGE, // '..'
     SPREAD, // '...'
     ARROW, // '->'
@@ -233,6 +234,7 @@ pub fn next(self: *Self, allocator: std.mem.Allocator) Self.Error!Token {
         '#' => .HASH,
         '?' => .QUESTION,
         '$' => .DOLLAR,
+        ',' => .COMMA,
 
         '.' => self.lexDots(),
 
@@ -789,8 +791,8 @@ test "Lex numbers" {
         .lexeme = "0",
         .literal = .{ .integer = 0 },
     }, try lexer.next(alloc));
-    
-        try std.testing.expectEqualDeep(Token{
+
+    try std.testing.expectEqualDeep(Token{
         .type = .FLOAT_LITERAL,
         .span = .{ .start = 41, .end = 45 },
         .lexeme = "14E4",

--- a/src/parse/Parser.zig
+++ b/src/parse/Parser.zig
@@ -202,11 +202,14 @@ pub fn parseWholeSource(self: *Self) !usize {
         // TODO: Add this back after special tokens are added to the lexer.
         // self.expect(.SEMICOLON);
     }
+
+    const body = try self.tree.addNode(.{
+        .span = self.peekSpan(),
+        .kind = .{ .code_block = try module_statements.toOwnedSlice() },
+    });
     return try self.tree.addNode(.{
         .span = self.peekSpan(),
-        .kind = .{ .module = .{
-            .statements = try module_statements.toOwnedSlice(),
-        } },
+        .kind = .{ .module = .{ .body = body } },
     });
 }
 
@@ -277,7 +280,8 @@ test "parseWholeSource method should parse multiple statements" {
     const module_node = parser.tree.getNodeUnsafe(module);
     try std.testing.expectEqualDeep(common.Span{ .start = 0, .end = 51 }, module_node.span);
     try std.testing.expectEqualDeep("module", @tagName(module_node.kind));
-    try std.testing.expectEqual(2, module_node.kind.module.statements.len);
+    const body_node = parser.tree.getNodeUnsafe(module_node.kind.module.body);
+    try std.testing.expectEqual(2, body_node.kind.code_block.len);
 }
 
 test "Parse `import` statement" {

--- a/src/parse/ast.zig
+++ b/src/parse/ast.zig
@@ -19,6 +19,7 @@ pub const NodeKind = union(enum) {
     // This is a standard string literal. Template literals will be separate.
     string_literal: []const u8,
     parameter: Parameter,
+    native_parameter: NativeParameter,
     code_block: []const NodeId,
 
     // ---< Special nodes >---
@@ -27,6 +28,7 @@ pub const NodeKind = union(enum) {
     // ---< Statement nodes >---
     import: Import,
     function_def: FunctionDef,
+    native_function_decl: NativeFunctionDecl,
 
     // ---< Expression nodes >---
 };
@@ -66,5 +68,22 @@ pub const FunctionDef = struct {
 // this is what function definitions hold.
 pub const Parameter = struct {
     name: NodeId,
+};
+
+// Native function declaration. This is equivalent to the following code:
+// `native "C" fn name(arg1, arg2: i32);`
+pub const NativeFunctionDecl = struct {
+    abi: ?NodeId,
+    name: NodeId,
+    parameters: []const NodeId,
+};
+
+// Parameter for native function. This is different from standard parameter
+// because it also can contain native type name.
+// If no type is provided this is equivalent to passing interpreters value pointer
+// and assuming this function is made specifically for Patapim language.
+pub const NativeParameter = struct {
+    name: NodeId,
+    type: ?NodeId,
 };
 // ---< AST Nodes end >---

--- a/src/parse/ast.zig
+++ b/src/parse/ast.zig
@@ -18,7 +18,7 @@ pub const NodeKind = union(enum) {
     identifier: []const u8,
     // This is a standard string literal. Template literals will be separate.
     string_literal: []const u8,
-    parameters: []const Parameter,
+    parameter: Parameter,
     code_block: []const NodeId,
 
     // ---< Special nodes >---
@@ -57,7 +57,7 @@ pub const Import = struct {
 // Native functions are defined by NativeFunctionDecl.
 pub const FunctionDef = struct {
     name: NodeId,
-    parameters: NodeId,
+    parameters: []const NodeId,
     body: NodeId,
 };
 

--- a/src/parse/ast.zig
+++ b/src/parse/ast.zig
@@ -18,12 +18,15 @@ pub const NodeKind = union(enum) {
     identifier: []const u8,
     // This is a standard string literal. Template literals will be separate.
     string_literal: []const u8,
+    parameters: []const Parameter,
+    code_block: []const NodeId,
 
     // ---< Special nodes >---
     module: Module,
 
     // ---< Statement nodes >---
     import: Import,
+    function_def: FunctionDef,
 
     // ---< Expression nodes >---
 };
@@ -38,7 +41,7 @@ pub const NodeId = usize;
 // no corresponding langauge syntax. This is just a wrapper
 // to provide one ID with whole top-level code.
 pub const Module = struct {
-    statements: []const usize,
+    body: NodeId,
 };
 
 // Import statement. This is equivalent to one of the examples below:
@@ -49,4 +52,19 @@ pub const Import = struct {
     opt_rename: ?NodeId = null,
 };
 
+// Function definition. This is equivalent to the following code:
+// `fn name(arg1, arg2) { ... }`
+// Native functions are defined by NativeFunctionDecl.
+pub const FunctionDef = struct {
+    name: NodeId,
+    parameters: NodeId,
+    body: NodeId,
+};
+
+// Function parameter, this is currently only identifier.
+// But for purposes of extensibility (and future-proofing attributes),
+// this is what function definitions hold.
+pub const Parameter = struct {
+    name: NodeId,
+};
 // ---< AST Nodes end >---


### PR DESCRIPTION
This PR implements parsing for native function declarations.
There have been a few changes in the syntax for this statement kind, where now it takes ABI and optional C types for arguments.