### PR TITLE
Expression parsing with precedence

### DIFF
--- a/spec/lexer.md
+++ b/spec/lexer.md
@@ -28,6 +28,7 @@ Names are just examples, they can be changed in the implementation.
 '|'  BITWISE_OR
 '&'  BITWISE_AND
 '^'  BITWISE_XOR
+'~'  BITWISE_NOT
 'and'/'&&' LOGICAL_AND
 'or'/'||'  LOGICAL_OR
 '<<' BITSHIFT_LEFT

--- a/src/Lexer.zig
+++ b/src/Lexer.zig
@@ -886,3 +886,93 @@ test "Lex comments and whitespace characters" {
         .lexeme = "",
     }, try lexer.next(alloc));
 }
+
+test "Lex operators" {
+    const source = "== > <= != << + ++ -- || ^ = . ... ..";
+    var lexer = Self{ .source = source };
+    const alloc = std.testing.allocator;
+
+    try std.testing.expectEqualDeep(Token{
+        .type = .EQ_EQ,
+        .span = .{ .start = 0, .end = 2 },
+        .lexeme = "==",
+    }, try lexer.next(alloc));
+
+    try std.testing.expectEqualDeep(Token{
+        .type = .GREATER_THAN,
+        .span = .{ .start = 3, .end = 4 },
+        .lexeme = ">",
+    }, try lexer.next(alloc));
+
+    try std.testing.expectEqualDeep(Token{
+        .type = .LESS_EQUAL,
+        .span = .{ .start = 5, .end = 7 },
+        .lexeme = "<=",
+    }, try lexer.next(alloc));
+
+    try std.testing.expectEqualDeep(Token{
+        .type = .NOT_EQ,
+        .span = .{ .start = 8, .end = 10 },
+        .lexeme = "!=",
+    }, try lexer.next(alloc));
+
+    try std.testing.expectEqualDeep(Token{
+        .type = .BITSHIFT_LEFT,
+        .span = .{ .start = 11, .end = 13 },
+        .lexeme = "<<",
+    }, try lexer.next(alloc));
+
+    try std.testing.expectEqualDeep(Token{
+        .type = .ADD,
+        .span = .{ .start = 14, .end = 15 },
+        .lexeme = "+",
+    }, try lexer.next(alloc));
+
+    try std.testing.expectEqualDeep(Token{
+        .type = .INCREMENT,
+        .span = .{ .start = 16, .end = 18 },
+        .lexeme = "++",
+    }, try lexer.next(alloc));
+
+    try std.testing.expectEqualDeep(Token{
+        .type = .DECREMENT,
+        .span = .{ .start = 19, .end = 21 },
+        .lexeme = "--",
+    }, try lexer.next(alloc));
+
+    try std.testing.expectEqualDeep(Token{
+        .type = .LOGICAL_OR,
+        .span = .{ .start = 22, .end = 24 },
+        .lexeme = "||",
+    }, try lexer.next(alloc));
+
+    try std.testing.expectEqualDeep(Token{
+        .type = .BITWISE_XOR,
+        .span = .{ .start = 25, .end = 26 },
+        .lexeme = "^",
+    }, try lexer.next(alloc));
+
+    try std.testing.expectEqualDeep(Token{
+        .type = .ASSIGN,
+        .span = .{ .start = 27, .end = 28 },
+        .lexeme = "=",
+    }, try lexer.next(alloc));
+
+    try std.testing.expectEqualDeep(Token{
+        .type = .DOT,
+        .span = .{ .start = 29, .end = 30 },
+        .lexeme = ".",
+    }, try lexer.next(alloc));
+
+    try std.testing.expectEqualDeep(Token{
+        .type = .SPREAD,
+        .span = .{ .start = 31, .end = 34 },
+        .lexeme = "...",
+    }, try lexer.next(alloc));
+
+    try std.testing.expectEqualDeep(Token{
+        .type = .RANGE,
+        .span = .{ .start = 35, .end = 37 },
+        .lexeme = "..",
+    }, try lexer.next(alloc));
+}

--- a/src/Lexer.zig
+++ b/src/Lexer.zig
@@ -96,12 +96,13 @@ pub const TokenType = enum {
 
     //Logical and Bitwise Operators
     BANG, // '!'
+    BITWISE_NOT, // '~'
     BITWISE_OR, // '|'
     BITWISE_AND, // '&'
     BITWISE_XOR, // '^'
     LOGICAL_AND, // 'and' || '&&'
     LOGICAL_OR, // 'or' || '||'
-    BTISHIFT_LEFT, // '<<'
+    BITSHIFT_LEFT, // '<<'
     BITSHIFT_RIGHT, // '>>'
 
     //Assignment variants (bitwise operators)
@@ -235,6 +236,7 @@ pub fn next(self: *Self, allocator: std.mem.Allocator) Self.Error!Token {
         '?' => .QUESTION,
         '$' => .DOLLAR,
         ',' => .COMMA,
+        '~' => .BITWISE_NOT,
 
         '.' => self.lexDots(),
 
@@ -302,7 +304,7 @@ fn lexOperators(self: *Self) TokenType {
     switch (char1) {
         '<' => switch (char2) {
             '=' => return .LESS_EQUAL,
-            '<' => return .BTISHIFT_LEFT,
+            '<' => return .BITSHIFT_LEFT,
             else => {
                 self.current -= 1;
                 return .LESS_THAN;
@@ -375,7 +377,7 @@ fn lexOperators(self: *Self) TokenType {
             '=' => return .MUL_ASSIGN,
             else => {
                 self.current -= 1;
-                return .SUBTRACT;
+                return .MULTIPLY;
             },
         },
         '/' => switch (char2) {
@@ -882,95 +884,5 @@ test "Lex comments and whitespace characters" {
         .type = .EOF,
         .span = .{ .start = source.len, .end = source.len },
         .lexeme = "",
-    }, try lexer.next(alloc));
-}
-
-test "Lex operators" {
-    const source = "== > <= != << + ++ -- || ^ = . ... ..";
-    var lexer = Self{ .source = source };
-    const alloc = std.testing.allocator;
-
-    try std.testing.expectEqualDeep(Token{
-        .type = .EQ_EQ,
-        .span = .{ .start = 0, .end = 2 },
-        .lexeme = "==",
-    }, try lexer.next(alloc));
-
-    try std.testing.expectEqualDeep(Token{
-        .type = .GREATER_THAN,
-        .span = .{ .start = 3, .end = 4 },
-        .lexeme = ">",
-    }, try lexer.next(alloc));
-
-    try std.testing.expectEqualDeep(Token{
-        .type = .LESS_EQUAL,
-        .span = .{ .start = 5, .end = 7 },
-        .lexeme = "<=",
-    }, try lexer.next(alloc));
-
-    try std.testing.expectEqualDeep(Token{
-        .type = .NOT_EQ,
-        .span = .{ .start = 8, .end = 10 },
-        .lexeme = "!=",
-    }, try lexer.next(alloc));
-
-    try std.testing.expectEqualDeep(Token{
-        .type = .BTISHIFT_LEFT,
-        .span = .{ .start = 11, .end = 13 },
-        .lexeme = "<<",
-    }, try lexer.next(alloc));
-
-    try std.testing.expectEqualDeep(Token{
-        .type = .ADD,
-        .span = .{ .start = 14, .end = 15 },
-        .lexeme = "+",
-    }, try lexer.next(alloc));
-
-    try std.testing.expectEqualDeep(Token{
-        .type = .INCREMENT,
-        .span = .{ .start = 16, .end = 18 },
-        .lexeme = "++",
-    }, try lexer.next(alloc));
-
-    try std.testing.expectEqualDeep(Token{
-        .type = .DECREMENT,
-        .span = .{ .start = 19, .end = 21 },
-        .lexeme = "--",
-    }, try lexer.next(alloc));
-
-    try std.testing.expectEqualDeep(Token{
-        .type = .LOGICAL_OR,
-        .span = .{ .start = 22, .end = 24 },
-        .lexeme = "||",
-    }, try lexer.next(alloc));
-
-    try std.testing.expectEqualDeep(Token{
-        .type = .BITWISE_XOR,
-        .span = .{ .start = 25, .end = 26 },
-        .lexeme = "^",
-    }, try lexer.next(alloc));
-
-    try std.testing.expectEqualDeep(Token{
-        .type = .ASSIGN,
-        .span = .{ .start = 27, .end = 28 },
-        .lexeme = "=",
-    }, try lexer.next(alloc));
-
-    try std.testing.expectEqualDeep(Token{
-        .type = .DOT,
-        .span = .{ .start = 29, .end = 30 },
-        .lexeme = ".",
-    }, try lexer.next(alloc));
-
-    try std.testing.expectEqualDeep(Token{
-        .type = .SPREAD,
-        .span = .{ .start = 31, .end = 34 },
-        .lexeme = "...",
-    }, try lexer.next(alloc));
-
-    try std.testing.expectEqualDeep(Token{
-        .type = .RANGE,
-        .span = .{ .start = 35, .end = 37 },
-        .lexeme = "..",
     }, try lexer.next(alloc));
 }

--- a/src/common.zig
+++ b/src/common.zig
@@ -57,6 +57,15 @@ pub fn Tree(comptime Node: type) type {
             return null;
         }
 
+        // Replaces node in the tree with a new one.
+        // If node with given ID does not exist, this returns IndexOutOfBounds error.
+        pub fn replaceNode(self: *Self, id: usize, new_node: Node) !void {
+            if (id >= self.nodes.items.len) {
+                return error.NodeNotFound;
+            }
+            self.nodes.items[id] = new_node;
+        }
+
         // Gets node from the tree with an assumption that it exists.
         // Avoid calling this, as it may cause segmentation faults.
         pub inline fn getNodeUnsafe(self: *Self, id: usize) Node {

--- a/src/common.zig
+++ b/src/common.zig
@@ -57,15 +57,6 @@ pub fn Tree(comptime Node: type) type {
             return null;
         }
 
-        // Replaces node in the tree with a new one.
-        // If node with given ID does not exist, this returns IndexOutOfBounds error.
-        pub fn replaceNode(self: *Self, id: usize, new_node: Node) !void {
-            if (id >= self.nodes.items.len) {
-                return error.NodeNotFound;
-            }
-            self.nodes.items[id] = new_node;
-        }
-
         // Gets node from the tree with an assumption that it exists.
         // Avoid calling this, as it may cause segmentation faults.
         pub inline fn getNodeUnsafe(self: *Self, id: usize) Node {

--- a/src/parse/Parser.zig
+++ b/src/parse/Parser.zig
@@ -575,16 +575,12 @@ pub fn parseParenthesizedExpr(self: *Self) Self.Error!usize {
     const expr = try self.parseExpression();
     _ = try self.expect(.RIGHT_PAREN);
 
-    const expr_node = self.tree.getNode(expr).?;
-
-    const new_node = ast.Node{
+    return self.tree.addNode(.{
         .span = self.peekSpan(),
-        .kind = expr_node.kind,
-    };
-
-    try self.tree.replaceNode(expr, new_node); // Replace old node with new one.
-
-    return expr;
+        .kind = .{ .expression_group = .{
+            .expression = expr,
+        } },
+    });
 }
 
 pub fn getPrecedence(op: Token) u8 {
@@ -765,17 +761,28 @@ test "Parse expression with parentheses" {
         .span = .{ .start = 0, .end = 11 },
         .kind = .{
             .binary_operator = .{
-                .left = 2,
+                .left = 3,
                 .operator = .MULTIPLY,
-                .right = 3,
+                .right = 4,
             },
         },
     }, expr_node);
 
     // Left operand: (2 + 3)
-    const left_mul = parser.tree.getNode(2).?;
+    const left_mul = parser.tree.getNode(3).?;
     try std.testing.expectEqualDeep(ast.Node{
         .span = .{ .start = 0, .end = 7 },
+        .kind = .{
+            .expression_group = .{
+                .expression = 2,
+            },
+        },
+    }, left_mul);
+
+    // Inside parentheses: 2 + 3
+    const in_brackets = parser.tree.getNode(2).?;
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 1, .end = 6 },
         .kind = .{
             .binary_operator = .{
                 .left = 0,
@@ -783,10 +790,10 @@ test "Parse expression with parentheses" {
                 .right = 1,
             },
         },
-    }, left_mul);
+    }, in_brackets);
 
     // Right operand: 4
-    const right_mul = parser.tree.getNode(3).?;
+    const right_mul = parser.tree.getNode(4).?;
     try std.testing.expectEqualDeep(ast.Node{
         .span = .{ .start = 10, .end = 11 },
         .kind = .{ .integer_literal = 4 },
@@ -826,16 +833,17 @@ test "Parse complex expression with operators" {
     // 5: integer_literal 2
     // 6: identifier "abc"
     // 7: unary_operator abc++
-    // 8: binary_operator (2 + abc++)
-    // 9: binary_operator (8*4) / (2 + abc++)
-    //10: binary_operator (-2) == (...)
-    //11: identifier "a"
-    //12: identifier "b"
-    //13: unary_operator ~b
-    //14: integer_literal 3
-    //15: binary_operator (~b) + 3
-    //16: binary_operator a > (...)
-    //17: binary_operator (...) || (...)
+    // 8: brackets (2 + abc++)
+    // 9: binary_operator 2 + abc++
+    //10: binary_operator (8*4) / (2 + abc++)
+    //11: binary_operator (-2) == (...)
+    //12: identifier "a"
+    //13: identifier "b"
+    //14: unary_operator ~b
+    //15: integer_literal 3
+    //16: binary_operator (~b) + 3
+    //17: binary_operator a > (...)
+    //18: binary_operator (...) || (...)
 
     //
     // Now we validate from the top down:
@@ -846,35 +854,35 @@ test "Parse complex expression with operators" {
         .span = .{ .start = 0, .end = source.len },
         .kind = .{
             .binary_operator = .{
-                .left = 10,
+                .left = 11,
                 .operator = .LOGICAL_OR,
-                .right = 16,
+                .right = 17,
             },
         },
     }, expr_node);
 
     // Left of OR: ==
-    const eq_node = parser.tree.getNode(10).?;
+    const eq_node = parser.tree.getNode(11).?;
     try std.testing.expectEqualDeep(ast.Node{
         .span = .{ .start = 0, .end = 25 },
         .kind = .{
             .binary_operator = .{
                 .left = 1,
                 .operator = .EQ_EQ,
-                .right = 9,
+                .right = 10,
             },
         },
     }, eq_node);
 
     // Right of OR: >
-    const gt_node = parser.tree.getNode(16).?;
+    const gt_node = parser.tree.getNode(17).?;
     try std.testing.expectEqualDeep(ast.Node{
         .span = .{ .start = 29, .end = 39 },
         .kind = .{
             .binary_operator = .{
-                .left = 11,
+                .left = 12,
                 .operator = .GREATER_THAN,
-                .right = 15,
+                .right = 16,
             },
         },
     }, gt_node);
@@ -899,14 +907,14 @@ test "Parse complex expression with operators" {
     }, lit2);
 
     // Right operand of ==
-    const div_node = parser.tree.getNode(9).?;
+    const div_node = parser.tree.getNode(10).?;
     try std.testing.expectEqualDeep(ast.Node{
         .span = .{ .start = 6, .end = 25 },
         .kind = .{
             .binary_operator = .{
                 .left = 4,
                 .operator = .DIVIDE,
-                .right = 8,
+                .right = 9,
             },
         },
     }, div_node);
@@ -939,9 +947,19 @@ test "Parse complex expression with operators" {
     }, lit4);
 
     // (2 + abc++)
-    const plus_node = parser.tree.getNode(8).?;
+    const plus_node_in_brackets = parser.tree.getNode(9).?;
     try std.testing.expectEqualDeep(ast.Node{
         .span = .{ .start = 14, .end = 25 },
+        .kind = .{
+            .expression_group = .{
+                .expression = 8,
+            },
+        },
+    }, plus_node_in_brackets);
+
+    const plus_node = parser.tree.getNode(8).?;
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 15, .end = 24 },
         .kind = .{
             .binary_operator = .{
                 .left = 5,
@@ -978,46 +996,46 @@ test "Parse complex expression with operators" {
     }, id_abc);
 
     // Left of >: a
-    const id_a = parser.tree.getNode(11).?;
+    const id_a = parser.tree.getNode(12).?;
     try std.testing.expectEqualDeep(ast.Node{
         .span = .{ .start = 29, .end = 30 },
         .kind = .{ .identifier = "a" },
     }, id_a);
 
     // (~b) + 3
-    const plus_b3 = parser.tree.getNode(15).?;
+    const plus_b3 = parser.tree.getNode(16).?;
     try std.testing.expectEqualDeep(ast.Node{
         .span = .{ .start = 33, .end = 39 },
         .kind = .{
             .binary_operator = .{
-                .left = 13,
+                .left = 14,
                 .operator = .ADD,
-                .right = 14,
+                .right = 15,
             },
         },
     }, plus_b3);
 
     // ~b
-    const not_b = parser.tree.getNode(13).?;
+    const not_b = parser.tree.getNode(14).?;
     try std.testing.expectEqualDeep(ast.Node{
         .span = .{ .start = 33, .end = 35 },
         .kind = .{
             .unary_operator = .{
                 .operator = .BITWISE_NOT,
-                .operand = 12,
+                .operand = 13,
             },
         },
     }, not_b);
 
     // identifier b
-    const id_b = parser.tree.getNode(12).?;
+    const id_b = parser.tree.getNode(13).?;
     try std.testing.expectEqualDeep(ast.Node{
         .span = .{ .start = 34, .end = 35 },
         .kind = .{ .identifier = "b" },
     }, id_b);
 
     // 3 literal
-    const lit3 = parser.tree.getNode(14).?;
+    const lit3 = parser.tree.getNode(15).?;
     try std.testing.expectEqualDeep(ast.Node{
         .span = .{ .start = 38, .end = 39 },
         .kind = .{ .integer_literal = 3 },

--- a/src/parse/Parser.zig
+++ b/src/parse/Parser.zig
@@ -398,8 +398,12 @@ pub fn parseCodeBlock(self: *Self) !usize {
     });
 }
 
+pub fn parseExpression(self: *Self) !usize {
+    return try self.parseBinaryExpression(0); // 0 precedence means we can parse any expression.
+}
+
 // Parse expression and return its ID if parsed.
-pub fn parseExpression(self: *Self, precedence: u8) !usize {
+pub fn parseBinaryExpression(self: *Self, precedence: u8) !usize {
     var left = try self.parseAtom();
 
     while (true) {
@@ -413,7 +417,9 @@ pub fn parseExpression(self: *Self, precedence: u8) !usize {
         }
 
         _ = try self.expect(next.type);
-        const right = try parseExpression(self, nextPrecedence);
+
+        // Parse the right-hand side of the expression if assignment.
+        const right = try parseBinaryExpression(self, if (nextPrecedence == 1) nextPrecedence - 1 else nextPrecedence);
 
         const left_node = self.tree.getNode(left).?;
         const right_node = self.tree.getNode(right).?;
@@ -423,31 +429,52 @@ pub fn parseExpression(self: *Self, precedence: u8) !usize {
                 .start = left_node.span.start,
                 .end = right_node.span.end,
             },
-            .kind = .{
-                .binary_operator = .{
-                    .left = left,
-                    .operator = switch (next.type) {
-                        .MULTIPLY => .MULTIPLY,
-                        .DIVIDE => .DIVIDE,
-                        .MODULO => .MODULO,
-                        .ADD => .ADD,
-                        .SUBTRACT => .SUBTRACT,
-                        .BITSHIFT_RIGHT => .BITSHIFT_RIGHT,
-                        .BITSHIFT_LEFT => .BITSHIFT_LEFT,
-                        .LESS_THAN => .LESS_THAN,
-                        .LESS_EQUAL => .LESS_EQUAL,
-                        .GREATER_THAN => .GREATER_THAN,
-                        .GREATER_EQUAL => .GREATER_EQUAL,
-                        .EQ_EQ => .EQ_EQ,
-                        .NOT_EQ => .NOT_EQ,
-                        .BITWISE_AND => .BITWISE_AND,
-                        .BITWISE_XOR => .BITWISE_XOR,
-                        .BITWISE_OR => .BITWISE_OR,
-                        .LOGICAL_AND => .LOGICAL_AND,
-                        .LOGICAL_OR => .LOGICAL_OR,
-                        else => unreachable,
+            .kind = switch (nextPrecedence) {
+                // Assignments:
+                1 => .{
+                    .assignment = .{
+                        .operator = switch (next.type) {
+                            .ASSIGN => .ASSIGN,
+                            .ADD_ASSIGN => .ADD_ASSIGN,
+                            .SUB_ASSIGN => .SUB_ASSIGN,
+                            .MUL_ASSIGN => .MUL_ASSIGN,
+                            .DIV_ASSIGN => .DIV_ASSIGN,
+                            .MOD_ASSIGN => .MOD_ASSIGN,
+                            .BITWISE_AND_ASSIGN => .BITWISE_AND_ASSIGN,
+                            .BITWISE_OR_ASSIGN => .BITWISE_OR_ASSIGN,
+                            .BITWISE_XOR_ASSIGN => .BITWISE_XOR_ASSIGN,
+                            else => unreachable,
+                        },
+                        .target = left,
+                        .value = right,
                     },
-                    .right = right,
+                },
+                else => .{
+                    .binary_operator = .{
+                        .left = left,
+                        .operator = switch (next.type) {
+                            .MULTIPLY => .MULTIPLY,
+                            .DIVIDE => .DIVIDE,
+                            .MODULO => .MODULO,
+                            .ADD => .ADD,
+                            .SUBTRACT => .SUBTRACT,
+                            .BITSHIFT_RIGHT => .BITSHIFT_RIGHT,
+                            .BITSHIFT_LEFT => .BITSHIFT_LEFT,
+                            .LESS_THAN => .LESS_THAN,
+                            .LESS_EQUAL => .LESS_EQUAL,
+                            .GREATER_THAN => .GREATER_THAN,
+                            .GREATER_EQUAL => .GREATER_EQUAL,
+                            .EQ_EQ => .EQ_EQ,
+                            .NOT_EQ => .NOT_EQ,
+                            .BITWISE_AND => .BITWISE_AND,
+                            .BITWISE_XOR => .BITWISE_XOR,
+                            .BITWISE_OR => .BITWISE_OR,
+                            .LOGICAL_AND => .LOGICAL_AND,
+                            .LOGICAL_OR => .LOGICAL_OR,
+                            else => unreachable,
+                        },
+                        .right = right,
+                    },
                 },
             },
         });
@@ -545,7 +572,7 @@ pub fn parseParenthesizedExpr(self: *Self) Self.Error!usize {
     try self.pushSpan();
     defer _ = self.popSpan();
 
-    const expr = try self.parseExpression(0); // 0 precedence means we can parse any expression.
+    const expr = try self.parseExpression();
     _ = try self.expect(.RIGHT_PAREN);
 
     const expr_node = self.tree.getNode(expr).?;
@@ -562,16 +589,17 @@ pub fn parseParenthesizedExpr(self: *Self) Self.Error!usize {
 
 pub fn getPrecedence(op: Token) u8 {
     switch (op.type) {
-        .MULTIPLY, .DIVIDE, .MODULO => return 10,
-        .ADD, .SUBTRACT => return 9,
-        .BITSHIFT_RIGHT, .BITSHIFT_LEFT => return 8,
-        .LESS_THAN, .LESS_EQUAL, .GREATER_THAN, .GREATER_EQUAL => return 7,
-        .EQ_EQ, .NOT_EQ => return 6,
-        .BITWISE_AND => return 5,
-        .BITWISE_XOR => return 4,
-        .BITWISE_OR => return 3,
-        .LOGICAL_AND => return 2,
-        .LOGICAL_OR => return 1,
+        .MULTIPLY, .DIVIDE, .MODULO => return 11,
+        .ADD, .SUBTRACT => return 10,
+        .BITSHIFT_RIGHT, .BITSHIFT_LEFT => return 9,
+        .LESS_THAN, .LESS_EQUAL, .GREATER_THAN, .GREATER_EQUAL => return 8,
+        .EQ_EQ, .NOT_EQ => return 7,
+        .BITWISE_AND => return 6,
+        .BITWISE_XOR => return 5,
+        .BITWISE_OR => return 4,
+        .LOGICAL_AND => return 3,
+        .LOGICAL_OR => return 2,
+        .ASSIGN, .ADD_ASSIGN, .SUB_ASSIGN, .MUL_ASSIGN, .DIV_ASSIGN, .MOD_ASSIGN, .BITWISE_AND_ASSIGN, .BITWISE_OR_ASSIGN, .BITWISE_XOR_ASSIGN => return 1,
         else => return 0, // No precedence for other tokens.
     }
 }
@@ -681,7 +709,7 @@ test "Parse broken simple addition expression expecting error" {
 
     try std.testing.expectError(
         error.ExpectedExpressionAtom,
-        parser.parseExpression(0),
+        parser.parseExpression(),
     );
 }
 
@@ -692,7 +720,7 @@ test "Parse simple addition expression" {
     defer parser.deinit(true);
 
     // Parse the expression
-    const expr_id = try parser.parseExpression(0);
+    const expr_id = try parser.parseExpression();
     const expr_node = parser.tree.getNode(expr_id).?;
 
     // Verify root node structure
@@ -729,7 +757,7 @@ test "Parse expression with parentheses" {
     defer parser.deinit(true);
 
     // Parse the expression
-    const expr_id = try parser.parseExpression(0);
+    const expr_id = try parser.parseExpression();
     const expr_node = parser.tree.getNode(expr_id).?;
 
     // Root node: *
@@ -785,7 +813,7 @@ test "Parse complex expression with operators" {
     var parser = Self.init(std.testing.allocator, &lexer);
     defer parser.deinit(true);
 
-    const expr_id = try parser.parseExpression(0);
+    const expr_id = try parser.parseExpression();
     const expr_node = parser.tree.getNode(expr_id).?;
 
     // IDs assigned in order:
@@ -994,4 +1022,61 @@ test "Parse complex expression with operators" {
         .span = .{ .start = 38, .end = 39 },
         .kind = .{ .integer_literal = 3 },
     }, lit3);
+}
+
+test "Parse assignment" {
+    const source = "a += b = 2";
+    var lexer: Lexer = .{ .source = source };
+    var parser = Self.init(std.testing.allocator, &lexer);
+    defer parser.deinit(true);
+
+    // Parse the expression
+    const expr_id = try parser.parseExpression();
+    const expr_node = parser.tree.getNode(expr_id).?;
+
+    // Root node: assignment '+='
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 0, .end = 10 },
+        .kind = .{
+            .assignment = .{
+                .operator = .ADD_ASSIGN,
+                .target = 0,
+                .value = 3,
+            },
+        },
+    }, expr_node);
+
+    // target of '+=': identifier 'a'
+    const target_add_assign = parser.tree.getNode(0).?;
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 0, .end = 1 },
+        .kind = .{ .identifier = "a" },
+    }, target_add_assign);
+
+    // value of '+=': assignment '='
+    const value_add_assign = parser.tree.getNode(3).?;
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 5, .end = 10 },
+        .kind = .{
+            .assignment = .{
+                .operator = .ASSIGN,
+                .target = 1,
+                .value = 2,
+            },
+        },
+    }, value_add_assign);
+
+    // target of '=': identifier 'b'
+    const target_assign = parser.tree.getNode(1).?;
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 5, .end = 6 },
+        .kind = .{ .identifier = "b" },
+    }, target_assign);
+
+    // value of '=': integer literal 2
+    const value_assign = parser.tree.getNode(2).?;
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 9, .end = 10 },
+        .kind = .{ .integer_literal = 2 },
+    }, value_assign);
 }

--- a/src/parse/Parser.zig
+++ b/src/parse/Parser.zig
@@ -32,6 +32,8 @@ const LOG = std.log.scoped(.parser);
 pub const Error = error{
     UnexpectedToken,
     ExpectedStatement,
+    NodeNotFound,
+    ExpectedExpressionAtom,
 } || Lexer.Error || std.mem.Allocator.Error;
 
 pub fn init(alloc: std.mem.Allocator, lexer: *Lexer) Self {
@@ -396,6 +398,184 @@ pub fn parseCodeBlock(self: *Self) !usize {
     });
 }
 
+// Parse expression and return its ID if parsed.
+pub fn parseExpression(self: *Self, precedence: u8) !usize {
+    var left = try self.parseAtom();
+
+    while (true) {
+        const next = try self.peek();
+        const nextPrecedence = getPrecedence(next);
+
+        if (nextPrecedence <= precedence) {
+            // If next precedence is less than or equal to current precedence,
+            // we stop parsing expressions.
+            break;
+        }
+
+        _ = try self.expect(next.type);
+        const right = try parseExpression(self, nextPrecedence);
+
+        const left_node = self.tree.getNode(left).?;
+        const right_node = self.tree.getNode(right).?;
+
+        left = try self.tree.addNode(.{
+            .span = .{
+                .start = left_node.span.start,
+                .end = right_node.span.end,
+            },
+            .kind = .{
+                .binary_operator = .{
+                    .left = left,
+                    .operator = switch (next.type) {
+                        .MULTIPLY => .MULTIPLY,
+                        .DIVIDE => .DIVIDE,
+                        .MODULO => .MODULO,
+                        .ADD => .ADD,
+                        .SUBTRACT => .SUBTRACT,
+                        .BITSHIFT_RIGHT => .BITSHIFT_RIGHT,
+                        .BITSHIFT_LEFT => .BITSHIFT_LEFT,
+                        .LESS_THAN => .LESS_THAN,
+                        .LESS_EQUAL => .LESS_EQUAL,
+                        .GREATER_THAN => .GREATER_THAN,
+                        .GREATER_EQUAL => .GREATER_EQUAL,
+                        .EQ_EQ => .EQ_EQ,
+                        .NOT_EQ => .NOT_EQ,
+                        .BITWISE_AND => .BITWISE_AND,
+                        .BITWISE_XOR => .BITWISE_XOR,
+                        .BITWISE_OR => .BITWISE_OR,
+                        .LOGICAL_AND => .LOGICAL_AND,
+                        .LOGICAL_OR => .LOGICAL_OR,
+                        else => unreachable,
+                    },
+                    .right = right,
+                },
+            },
+        });
+    }
+
+    return left;
+}
+
+pub fn parseAtom(self: *Self) !usize {
+    const token = try self.advance();
+
+    return switch (token.type) {
+        .INTEGER_LITERAL => try self.tree.addNode(.{
+            .span = token.span,
+            .kind = .{ .integer_literal = token.literal.integer },
+        }),
+        .FLOAT_LITERAL => try self.tree.addNode(.{
+            .span = token.span,
+            .kind = .{ .float_literal = token.literal.float },
+        }),
+        .STRING_LITERAL => try self.tree.addNode(.{
+            .span = token.span,
+            .kind = .{ .string_literal = token.literal.string },
+        }),
+        .KW_TRUE, .KW_FALSE => try self.tree.addNode(.{
+            .span = token.span,
+            .kind = .{ .boolean_literal = token.type == .KW_TRUE },
+        }),
+        .BANG, .BITWISE_NOT, .SUBTRACT => try self.parseUnaryOperator(token),
+        .LEFT_PAREN => try self.parseParenthesizedExpr(),
+        .IDENTIFIER => {
+            try self.pushSpan();
+            defer _ = self.popSpan();
+
+            const iden = try self.tree.addNode(.{
+                .span = token.span,
+                .kind = .{ .identifier = token.lexeme },
+            });
+
+            const next = try self.peek();
+            if (next.type == .INCREMENT or next.type == .DECREMENT) {
+                _ = try self.expect(next.type);
+                return self.tree.addNode(.{
+                    .span = self.peekSpan(),
+                    .kind = .{ .unary_operator = .{
+                        .operand = iden,
+                        .operator = switch (next.type) {
+                            .INCREMENT => .INCREMENT,
+                            .DECREMENT => .DECREMENT,
+                            else => unreachable,
+                        },
+                    } },
+                });
+            }
+
+            return iden;
+        },
+        else => return self.reportError(
+            "P003",
+            "Expected an expression atom.",
+            .{},
+            error.ExpectedExpressionAtom,
+            .{
+                .labels = &.{.{
+                    .color = .{ .basic = .magenta },
+                    .span = token.span.asReportz(),
+                    .message = "Found this instead.",
+                }},
+            },
+        ),
+    };
+}
+
+pub fn parseUnaryOperator(self: *Self, operator_token: Token) Self.Error!usize {
+    try self.pushSpan();
+    defer _ = self.popSpan();
+    const operand = try self.parseAtom();
+    return try self.tree.addNode(.{
+        .span = self.peekSpan(),
+        .kind = .{
+            .unary_operator = .{
+                .operator = switch (operator_token.type) {
+                    .BANG => .NOT,
+                    .BITWISE_NOT => .BITWISE_NOT,
+                    .SUBTRACT => .SUBTRACT, // Unary minus
+                    else => unreachable,
+                },
+                .operand = operand,
+            },
+        },
+    });
+}
+
+pub fn parseParenthesizedExpr(self: *Self) Self.Error!usize {
+    try self.pushSpan();
+    defer _ = self.popSpan();
+
+    const expr = try self.parseExpression(0); // 0 precedence means we can parse any expression.
+    _ = try self.expect(.RIGHT_PAREN);
+
+    const expr_node = self.tree.getNode(expr).?;
+
+    const new_node = ast.Node{
+        .span = self.peekSpan(),
+        .kind = expr_node.kind,
+    };
+
+    try self.tree.replaceNode(expr, new_node); // Replace old node with new one.
+
+    return expr;
+}
+
+pub fn getPrecedence(op: Token) u8 {
+    switch (op.type) {
+        .MULTIPLY, .DIVIDE, .MODULO => return 10,
+        .ADD, .SUBTRACT => return 9,
+        .BITSHIFT_RIGHT, .BITSHIFT_LEFT => return 8,
+        .LESS_THAN, .LESS_EQUAL, .GREATER_THAN, .GREATER_EQUAL => return 7,
+        .EQ_EQ, .NOT_EQ => return 6,
+        .BITWISE_AND => return 5,
+        .BITWISE_XOR => return 4,
+        .BITWISE_OR => return 3,
+        .LOGICAL_AND => return 2,
+        .LOGICAL_OR => return 1,
+        else => return 0, // No precedence for other tokens.
+    }
+}
+
 test "parseWholeSource method should parse multiple statements" {
     const source =
         \\import "source.brr";
@@ -491,4 +671,327 @@ test "Parse code block" {
         .span = .{ .start = 0, .end = 21 },
         .kind = .{ .code_block = &.{1} },
     }, block_node);
+}
+
+test "Parse broken simple addition expression expecting error" {
+    const source = "2 + ";
+    var lexer: Lexer = .{ .source = source };
+    var parser = Self.init(std.testing.allocator, &lexer);
+    defer parser.deinit(true);
+
+    try std.testing.expectError(
+        error.ExpectedExpressionAtom,
+        parser.parseExpression(0),
+    );
+}
+
+test "Parse simple addition expression" {
+    const source = "2 + 2";
+    var lexer: Lexer = .{ .source = source };
+    var parser = Self.init(std.testing.allocator, &lexer);
+    defer parser.deinit(true);
+
+    // Parse the expression
+    const expr_id = try parser.parseExpression(0);
+    const expr_node = parser.tree.getNode(expr_id).?;
+
+    // Verify root node structure
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 0, .end = 5 },
+        .kind = .{
+            .binary_operator = .{
+                .left = 0, // Left operand ID
+                .operator = .ADD,
+                .right = 1, // Right operand ID
+            },
+        },
+    }, expr_node);
+
+    // Verify left operand (first '2')
+    const left_node = parser.tree.getNode(expr_node.kind.binary_operator.left).?;
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 0, .end = 1 },
+        .kind = .{ .integer_literal = 2 },
+    }, left_node);
+
+    // Verify right operand (second '2')
+    const right_node = parser.tree.getNode(expr_node.kind.binary_operator.right).?;
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 4, .end = 5 },
+        .kind = .{ .integer_literal = 2 },
+    }, right_node);
+}
+
+test "Parse expression with parentheses" {
+    const source = "(2 + 3) * 4";
+    var lexer: Lexer = .{ .source = source };
+    var parser = Self.init(std.testing.allocator, &lexer);
+    defer parser.deinit(true);
+
+    // Parse the expression
+    const expr_id = try parser.parseExpression(0);
+    const expr_node = parser.tree.getNode(expr_id).?;
+
+    // Root node: *
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 0, .end = 11 },
+        .kind = .{
+            .binary_operator = .{
+                .left = 2,
+                .operator = .MULTIPLY,
+                .right = 3,
+            },
+        },
+    }, expr_node);
+
+    // Left operand: (2 + 3)
+    const left_mul = parser.tree.getNode(2).?;
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 0, .end = 7 },
+        .kind = .{
+            .binary_operator = .{
+                .left = 0,
+                .operator = .ADD,
+                .right = 1,
+            },
+        },
+    }, left_mul);
+
+    // Right operand: 4
+    const right_mul = parser.tree.getNode(3).?;
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 10, .end = 11 },
+        .kind = .{ .integer_literal = 4 },
+    }, right_mul);
+
+    // Left operand of +
+    const left_add = parser.tree.getNode(0).?;
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 1, .end = 2 },
+        .kind = .{ .integer_literal = 2 },
+    }, left_add);
+
+    // Right operand of +
+    const right_add = parser.tree.getNode(1).?;
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 5, .end = 6 },
+        .kind = .{ .integer_literal = 3 },
+    }, right_add);
+}
+
+test "Parse complex expression with operators" {
+    const source = "-2 == 8 * 4 / (2 + abc++) || a > ~b + 3";
+    var lexer: Lexer = .{ .source = source };
+    var parser = Self.init(std.testing.allocator, &lexer);
+    defer parser.deinit(true);
+
+    const expr_id = try parser.parseExpression(0);
+    const expr_node = parser.tree.getNode(expr_id).?;
+
+    // IDs assigned in order:
+    //
+    // 0: integer_literal 2
+    // 1: unary_operator -2
+    // 2: integer_literal 8
+    // 3: integer_literal 4
+    // 4: binary_operator 8 * 4
+    // 5: integer_literal 2
+    // 6: identifier "abc"
+    // 7: unary_operator abc++
+    // 8: binary_operator (2 + abc++)
+    // 9: binary_operator (8*4) / (2 + abc++)
+    //10: binary_operator (-2) == (...)
+    //11: identifier "a"
+    //12: identifier "b"
+    //13: unary_operator ~b
+    //14: integer_literal 3
+    //15: binary_operator (~b) + 3
+    //16: binary_operator a > (...)
+    //17: binary_operator (...) || (...)
+
+    //
+    // Now we validate from the top down:
+    //
+
+    // Top: OR
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 0, .end = source.len },
+        .kind = .{
+            .binary_operator = .{
+                .left = 10,
+                .operator = .LOGICAL_OR,
+                .right = 16,
+            },
+        },
+    }, expr_node);
+
+    // Left of OR: ==
+    const eq_node = parser.tree.getNode(10).?;
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 0, .end = 25 },
+        .kind = .{
+            .binary_operator = .{
+                .left = 1,
+                .operator = .EQ_EQ,
+                .right = 9,
+            },
+        },
+    }, eq_node);
+
+    // Right of OR: >
+    const gt_node = parser.tree.getNode(16).?;
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 29, .end = 39 },
+        .kind = .{
+            .binary_operator = .{
+                .left = 11,
+                .operator = .GREATER_THAN,
+                .right = 15,
+            },
+        },
+    }, gt_node);
+
+    // Left operand of ==
+    const minus2 = parser.tree.getNode(1).?;
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 0, .end = 2 },
+        .kind = .{
+            .unary_operator = .{
+                .operator = .SUBTRACT,
+                .operand = 0,
+            },
+        },
+    }, minus2);
+
+    // literal 2
+    const lit2 = parser.tree.getNode(0).?;
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 1, .end = 2 },
+        .kind = .{ .integer_literal = 2 },
+    }, lit2);
+
+    // Right operand of ==
+    const div_node = parser.tree.getNode(9).?;
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 6, .end = 25 },
+        .kind = .{
+            .binary_operator = .{
+                .left = 4,
+                .operator = .DIVIDE,
+                .right = 8,
+            },
+        },
+    }, div_node);
+
+    // 8 * 4
+    const mul_node = parser.tree.getNode(4).?;
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 6, .end = 11 },
+        .kind = .{
+            .binary_operator = .{
+                .left = 2,
+                .operator = .MULTIPLY,
+                .right = 3,
+            },
+        },
+    }, mul_node);
+
+    // 8 literal
+    const lit8 = parser.tree.getNode(2).?;
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 6, .end = 7 },
+        .kind = .{ .integer_literal = 8 },
+    }, lit8);
+
+    // 4 literal
+    const lit4 = parser.tree.getNode(3).?;
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 10, .end = 11 },
+        .kind = .{ .integer_literal = 4 },
+    }, lit4);
+
+    // (2 + abc++)
+    const plus_node = parser.tree.getNode(8).?;
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 14, .end = 25 },
+        .kind = .{
+            .binary_operator = .{
+                .left = 5,
+                .operator = .ADD,
+                .right = 7,
+            },
+        },
+    }, plus_node);
+
+    // literal 2
+    const lit2b = parser.tree.getNode(5).?;
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 15, .end = 16 },
+        .kind = .{ .integer_literal = 2 },
+    }, lit2b);
+
+    // abc++
+    const inc_node = parser.tree.getNode(7).?;
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 19, .end = 24 },
+        .kind = .{
+            .unary_operator = .{
+                .operator = .INCREMENT,
+                .operand = 6,
+            },
+        },
+    }, inc_node);
+
+    // abc identifier
+    const id_abc = parser.tree.getNode(6).?;
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 19, .end = 22 },
+        .kind = .{ .identifier = "abc" },
+    }, id_abc);
+
+    // Left of >: a
+    const id_a = parser.tree.getNode(11).?;
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 29, .end = 30 },
+        .kind = .{ .identifier = "a" },
+    }, id_a);
+
+    // (~b) + 3
+    const plus_b3 = parser.tree.getNode(15).?;
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 33, .end = 39 },
+        .kind = .{
+            .binary_operator = .{
+                .left = 13,
+                .operator = .ADD,
+                .right = 14,
+            },
+        },
+    }, plus_b3);
+
+    // ~b
+    const not_b = parser.tree.getNode(13).?;
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 33, .end = 35 },
+        .kind = .{
+            .unary_operator = .{
+                .operator = .BITWISE_NOT,
+                .operand = 12,
+            },
+        },
+    }, not_b);
+
+    // identifier b
+    const id_b = parser.tree.getNode(12).?;
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 34, .end = 35 },
+        .kind = .{ .identifier = "b" },
+    }, id_b);
+
+    // 3 literal
+    const lit3 = parser.tree.getNode(14).?;
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 38, .end = 39 },
+        .kind = .{ .integer_literal = 3 },
+    }, lit3);
 }

--- a/src/parse/ast.zig
+++ b/src/parse/ast.zig
@@ -29,6 +29,7 @@ pub const NodeKind = union(enum) {
     binary_operator: BinaryOperator,
     unary_operator: UnaryOperator,
     assignment: Assignment,
+    expression_group: ExpressionGroup,
 
     // ---< Special nodes >---
     module: Module,
@@ -116,6 +117,10 @@ pub const Assignment = struct {
     target: NodeId,
     operator: AssignmentOperator,
     value: NodeId, // Expression
+};
+
+pub const ExpressionGroup = struct {
+    expression: NodeId,
 };
 // ---< AST Nodes end >---
 

--- a/src/parse/ast.zig
+++ b/src/parse/ast.zig
@@ -28,6 +28,7 @@ pub const NodeKind = union(enum) {
     // --< Operator nodes >---
     binary_operator: BinaryOperator,
     unary_operator: UnaryOperator,
+    assignment: Assignment,
 
     // ---< Special nodes >---
     module: Module,
@@ -115,6 +116,14 @@ pub const UnaryOperator = struct {
     operator: Operator,
     operand: NodeId,
 };
+
+// This is equivalent to the following code:
+// `variable_name = value`
+pub const Assignment = struct {
+    target: NodeId,
+    operator: AssignmentOperator,
+    value: NodeId, // Expression
+};
 // ---< AST Nodes end >---
 
 // Operators are used in binary and unary operator nodes.
@@ -154,6 +163,22 @@ pub const Operator = enum {
     // Increment/Decrement operators
     INCREMENT, // '++'
     DECREMENT, // '--'
+
+    UNKNOWN,
+};
+
+// Assigment operator.
+// This is used to represent the operator itself, and not the whole expression.
+pub const AssignmentOperator = enum {
+    ASSIGN, // '='
+    ADD_ASSIGN, // '+='
+    SUB_ASSIGN, // '-='
+    MUL_ASSIGN, // '*='
+    DIV_ASSIGN, // '/='
+    MOD_ASSIGN, // '%='
+    BITWISE_AND_ASSIGN, // '&='
+    BITWISE_OR_ASSIGN, // '|='
+    BITWISE_XOR_ASSIGN, // '^='
 
     UNKNOWN,
 };

--- a/src/parse/ast.zig
+++ b/src/parse/ast.zig
@@ -95,13 +95,6 @@ pub const NativeParameter = struct {
     type: ?NodeId,
 };
 
-// Variable reference, this is equivalent to the following code:
-// `variable_name`
-// This is used to reference variables in expressions, statements, etc.
-pub const VariableReference = struct {
-    name: NodeId,
-};
-
 // Binary operator node. This is equivalent to the following code:
 // `left + right`
 pub const BinaryOperator = struct {

--- a/src/parse/ast.zig
+++ b/src/parse/ast.zig
@@ -18,9 +18,16 @@ pub const NodeKind = union(enum) {
     identifier: []const u8,
     // This is a standard string literal. Template literals will be separate.
     string_literal: []const u8,
+    integer_literal: u64,
+    float_literal: f64,
+    boolean_literal: bool,
     parameter: Parameter,
     native_parameter: NativeParameter,
     code_block: []const NodeId,
+
+    // --< Operator nodes >---
+    binary_operator: BinaryOperator,
+    unary_operator: UnaryOperator,
 
     // ---< Special nodes >---
     module: Module,
@@ -86,4 +93,67 @@ pub const NativeParameter = struct {
     name: NodeId,
     type: ?NodeId,
 };
+
+// Variable reference, this is equivalent to the following code:
+// `variable_name`
+// This is used to reference variables in expressions, statements, etc.
+pub const VariableReference = struct {
+    name: NodeId,
+};
+
+// Binary operator node. This is equivalent to the following code:
+// `left + right`
+pub const BinaryOperator = struct {
+    left: NodeId,
+    operator: Operator,
+    right: NodeId,
+};
+
+// Unary operator node. This is equivalent to the following code:
+// `operator operand`
+pub const UnaryOperator = struct {
+    operator: Operator,
+    operand: NodeId,
+};
 // ---< AST Nodes end >---
+
+// Operators are used in binary and unary operator nodes.
+// They are used to represent the operator itself, and not the whole expression.
+pub const Operator = enum {
+    // Arithmetic operators
+    ADD, // '+'
+    SUBTRACT, // '-'
+    MULTIPLY, // '*'
+    DIVIDE, // '/'
+    MODULO, // '%'
+
+    // Comparison operators
+    EQ_EQ, // '=='
+    NOT_EQ, // '!='
+    LESS_THAN, // '<'
+    LESS_EQUAL, // '<='
+    GREATER_THAN, // '>'
+    GREATER_EQUAL, // '>='
+
+    // Logical operators
+    LOGICAL_AND, // '&&'
+    LOGICAL_OR, // '||'
+
+    // Shift operators
+    BITSHIFT_LEFT, // '<<'
+    BITSHIFT_RIGHT, // '>>'
+
+    // Bitwise operators
+    BITWISE_AND, // '&'
+    BITWISE_OR, // '|'
+    BITWISE_XOR, // '^'
+
+    NOT, // '!'
+    BITWISE_NOT, // '~'
+
+    // Increment/Decrement operators
+    INCREMENT, // '++'
+    DECREMENT, // '--'
+
+    UNKNOWN,
+};


### PR DESCRIPTION
## Expression Parsing with Precedence

This PR adds expression parsing that respects **operator precedence** and **associativity**, including:

- Binary operators (`+`, `*`, `&&`, etc.) with correct precedence.
- **Right-associative assignments** (`=`, `+=`, etc.), so expressions like `a += b = 2` parse as `a += (b = 2)`.
- Parentheses and unary operators.
- AST nodes distinguishing `binary_operator` and `assignment`.

Also fixes some typos and minor bugs.

*Includes tests*