### PR TITLE
Parse loops

### DIFF
--- a/src/parse/Parser.zig
+++ b/src/parse/Parser.zig
@@ -225,6 +225,9 @@ pub fn parseAnyStatement(self: *Self) Self.Error!usize {
     if (try self.parseMaybeNativeFunctionDeclStatement()) |stmt| return stmt;
     if (try self.parseMaybeVariableDeclaration()) |stmt| return stmt;
     if (try self.parseMaybeConstantDeclaration()) |stmt| return stmt;
+    if (try self.parseMaybeLoop()) |stmt| return stmt;
+    //if (try self.parseMaybeWhileLoop()) |stmt| return stmt;
+    //if (try self.parseMaybeForLoop()) |stmt| return stmt;
     // If nothing has returned up to this point, we assume that there
     // is no statement where it should be and panic.
     return self.reportError(
@@ -260,6 +263,7 @@ pub fn parseMaybeVariableDeclaration(self: *Self) !?usize {
         } },
     });
 }
+
 // parse constant declaration statement and return its ID if parsed.
 // For more information please reference `ast.zig -> Const` struct.
 pub fn parseMaybeConstantDeclaration(self: *Self) !?usize {
@@ -413,6 +417,22 @@ pub fn parseMaybeNativeFunctionDeclStatement(self: *Self) !?usize {
             .abi = abi_node,
             .name = fn_name,
             .parameters = try fn_parameters.toOwnedSlice(),
+        } },
+    });
+}
+
+// Parse maybe loop statement and return its ID if parsed.
+pub fn parseMaybeLoop(self: *Self) !?usize {
+    if (try self.maybe(.KW_LOOP) == null) return null; // This may not be a loop statement.
+    try self.pushSpan();
+    defer _ = self.popSpan();
+
+    const body = try self.parseCodeBlock();
+
+    return try self.tree.addNode(.{
+        .span = self.peekSpan(),
+        .kind = .{ .loop = .{
+            .body = body,
         } },
     });
 }
@@ -753,6 +773,27 @@ test "Parse native function declaration statement" {
             .parameters = &.{ 4, 6 },
         } },
     }, fn_node);
+}
+
+test "Parse simple loop statement" {
+    const source = "loop {}";
+
+    var lexer: Lexer = .{ .source = source };
+    var parser = Self.init(std.testing.allocator, &lexer);
+    defer parser.deinit(true);
+
+    const expr_id = (try parser.parseMaybeLoop()).?;
+    const expr_node = parser.tree.getNode(expr_id).?;
+
+    // Root node: loop
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 0, .end = source.len },
+        .kind = .{
+            .loop = .{
+                .body = 0,
+            },
+        },
+    }, expr_node);
 }
 
 test "Parse code block" {

--- a/src/parse/Parser.zig
+++ b/src/parse/Parser.zig
@@ -226,7 +226,7 @@ pub fn parseAnyStatement(self: *Self) Self.Error!usize {
     if (try self.parseMaybeVariableDeclaration()) |stmt| return stmt;
     if (try self.parseMaybeConstantDeclaration()) |stmt| return stmt;
     if (try self.parseMaybeLoop()) |stmt| return stmt;
-    //if (try self.parseMaybeWhileLoop()) |stmt| return stmt;
+    if (try self.parseMaybeWhileLoop()) |stmt| return stmt;
     //if (try self.parseMaybeForLoop()) |stmt| return stmt;
     // If nothing has returned up to this point, we assume that there
     // is no statement where it should be and panic.
@@ -432,6 +432,27 @@ pub fn parseMaybeLoop(self: *Self) !?usize {
     return try self.tree.addNode(.{
         .span = self.peekSpan(),
         .kind = .{ .loop = .{
+            .body = body,
+        } },
+    });
+}
+
+// Parse maybe while loop statement and return its ID if parsed.
+pub fn parseMaybeWhileLoop(self: *Self) !?usize {
+    if (try self.maybe(.KW_WHILE) == null) return null; // This may not be a while loop statement.
+    try self.pushSpan();
+    defer _ = self.popSpan();
+
+    _ = try self.expect(.LEFT_PAREN);
+    const condition = try self.parseExpression();
+    _ = try self.expect(.RIGHT_PAREN);
+
+    const body = try self.parseCodeBlock();
+
+    return try self.tree.addNode(.{
+        .span = self.peekSpan(),
+        .kind = .{ .while_loop = .{
+            .condition = condition,
             .body = body,
         } },
     });
@@ -791,6 +812,28 @@ test "Parse simple loop statement" {
         .kind = .{
             .loop = .{
                 .body = 0,
+            },
+        },
+    }, expr_node);
+}
+
+test "Parse simple while loop statement" {
+    const source = "while(abc > 10) {}";
+
+    var lexer: Lexer = .{ .source = source };
+    var parser = Self.init(std.testing.allocator, &lexer);
+    defer parser.deinit(true);
+
+    const expr_id = (try parser.parseMaybeWhileLoop()).?;
+    const expr_node = parser.tree.getNode(expr_id).?;
+
+    // Root node: while_loop
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 0, .end = source.len },
+        .kind = .{
+            .while_loop = .{
+                .condition = 2,
+                .body = 3,
             },
         },
     }, expr_node);

--- a/src/parse/Parser.zig
+++ b/src/parse/Parser.zig
@@ -227,7 +227,8 @@ pub fn parseAnyStatement(self: *Self) Self.Error!usize {
     if (try self.parseMaybeConstantDeclaration()) |stmt| return stmt;
     if (try self.parseMaybeLoop()) |stmt| return stmt;
     if (try self.parseMaybeWhileLoop()) |stmt| return stmt;
-    //if (try self.parseMaybeForLoop()) |stmt| return stmt;
+    if (try self.parseMaybeForLoop()) |stmt| return stmt;
+
     // If nothing has returned up to this point, we assume that there
     // is no statement where it should be and panic.
     return self.reportError(
@@ -458,6 +459,29 @@ pub fn parseMaybeWhileLoop(self: *Self) !?usize {
     });
 }
 
+pub fn parseMaybeForLoop(self: *Self) !?usize {
+    if (try self.maybe(.KW_FOR) == null) return null; // This may not be a for loop statement.
+    try self.pushSpan();
+    defer _ = self.popSpan();
+
+    _ = try self.expect(.LEFT_PAREN);
+    const binding = try self.expectIdentifier();
+    _ = try self.expect(.KW_IN);
+    const iterable = try self.parseExpression();
+    _ = try self.expect(.RIGHT_PAREN);
+
+    const body = try self.parseCodeBlock();
+
+    return try self.tree.addNode(.{
+        .span = self.peekSpan(),
+        .kind = .{ .for_loop = .{
+            .binding = binding,
+            .iterable = iterable,
+            .body = body,
+        } },
+    });
+}
+
 // Parse block of code.
 // This is basically a statement list inside of `{}` parentheses.
 // This function assumes that caller has checked for `{` character already.
@@ -532,6 +556,7 @@ pub fn parseBinaryExpression(self: *Self, precedence: u8) !usize {
                     .binary_operator = .{
                         .left = left,
                         .operator = switch (next.type) {
+                            .RANGE => .RANGE,
                             .MULTIPLY => .MULTIPLY,
                             .DIVIDE => .DIVIDE,
                             .MODULO => .MODULO,
@@ -664,6 +689,7 @@ pub fn parseParenthesizedExpr(self: *Self) Self.Error!usize {
 
 pub fn getPrecedence(op: Token) u8 {
     switch (op.type) {
+        .RANGE => return 12,
         .MULTIPLY, .DIVIDE, .MODULO => return 11,
         .ADD, .SUBTRACT => return 10,
         .BITSHIFT_RIGHT, .BITSHIFT_LEFT => return 9,
@@ -834,6 +860,29 @@ test "Parse simple while loop statement" {
             .while_loop = .{
                 .condition = 2,
                 .body = 3,
+            },
+        },
+    }, expr_node);
+}
+
+test "Parse simple for loop statement" {
+    const source = "for(i in 1 .. 10) {}";
+
+    var lexer: Lexer = .{ .source = source };
+    var parser = Self.init(std.testing.allocator, &lexer);
+    defer parser.deinit(true);
+
+    const expr_id = (try parser.parseMaybeForLoop()).?;
+    const expr_node = parser.tree.getNode(expr_id).?;
+
+    // Root node: for_loop
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 0, .end = source.len },
+        .kind = .{
+            .for_loop = .{
+                .binding = 0,
+                .iterable = 3,
+                .body = 4,
             },
         },
     }, expr_node);

--- a/src/parse/Parser.zig
+++ b/src/parse/Parser.zig
@@ -661,6 +661,12 @@ fn parseConditional(self: *Self) !usize {
         _ = try self.expect(.KW_IF);
     }
 
+    _ = try self.expect(.LEFT_PAREN);
+    const condition = try self.parseExpression();
+    _ = try self.expect(.RIGHT_PAREN);
+
+    const body = try self.parseCodeBlock();
+
     var else_conditional: ?usize = null;
 
     if (try self.maybe(.KW_ELSE) != null) {
@@ -1181,7 +1187,7 @@ test "Parse simple loop statement" {
     var lexer: Lexer = .{ .source = source };
     var parser = Self.init(std.testing.allocator, &lexer);
     defer parser.deinit(true);
-    
+
     const expr_id = (try parser.parseMaybeLoop()).?;
     const expr_node = parser.tree.getNode(expr_id).?;
 
@@ -1201,7 +1207,7 @@ test "Parse simple while loop statement" {
     var lexer: Lexer = .{ .source = source };
     var parser = Self.init(std.testing.allocator, &lexer);
     defer parser.deinit(true);
-    
+
     const expr_id = (try parser.parseMaybeWhileLoop()).?;
     const expr_node = parser.tree.getNode(expr_id).?;
 
@@ -1222,7 +1228,6 @@ test "Parse simple for loop statement" {
     var lexer: Lexer = .{ .source = source };
     var parser = Self.init(std.testing.allocator, &lexer);
     defer parser.deinit(true);
-
 
     const expr_id = (try parser.parseMaybeForLoop()).?;
     const expr_node = parser.tree.getNode(expr_id).?;
@@ -1292,7 +1297,7 @@ test "Parse inline conditional expression" {
     var lexer: Lexer = .{ .source = source };
     var parser = Self.init(std.testing.allocator, &lexer);
     defer parser.deinit(true);
-    
+
     const expr_id = try parser.parseExpression();
     const expr_node = parser.tree.getNodeUnsafe(expr_id);
 

--- a/src/parse/ast.zig
+++ b/src/parse/ast.zig
@@ -41,6 +41,8 @@ pub const NodeKind = union(enum) {
     native_function_decl: NativeFunctionDecl,
     variable: Variable,
     constant: Const,
+    loop: Loop,
+
     // ---< Expression nodes >---
 };
 
@@ -108,6 +110,13 @@ pub const NativeFunctionDecl = struct {
 pub const NativeParameter = struct {
     name: NodeId,
     type: ?NodeId,
+};
+
+// Loop node. This is equivalent to the following code:
+// `loop { ... }`
+// This is a special node, because it has no condition.
+pub const Loop = struct {
+    body: NodeId,
 };
 
 // Binary operator node. This is equivalent to the following code:

--- a/src/parse/ast.zig
+++ b/src/parse/ast.zig
@@ -42,6 +42,7 @@ pub const NodeKind = union(enum) {
     variable: Variable,
     constant: Const,
     loop: Loop,
+    while_loop: WhileLoop,
 
     // ---< Expression nodes >---
 };
@@ -116,6 +117,13 @@ pub const NativeParameter = struct {
 // `loop { ... }`
 // This is a special node, because it has no condition.
 pub const Loop = struct {
+    body: NodeId,
+};
+
+// While loop node. This is equivalent to the following code:
+// `while(condition) { ... }`
+pub const WhileLoop = struct {
+    condition: NodeId,
     body: NodeId,
 };
 

--- a/src/parse/ast.zig
+++ b/src/parse/ast.zig
@@ -43,6 +43,7 @@ pub const NodeKind = union(enum) {
     constant: Const,
     loop: Loop,
     while_loop: WhileLoop,
+    for_loop: ForLoop,
 
     // ---< Expression nodes >---
 };
@@ -127,6 +128,14 @@ pub const WhileLoop = struct {
     body: NodeId,
 };
 
+// For loop node. This is equivalent to the following code:
+// `for (i in 0..10) { ... }`
+pub const ForLoop = struct {
+    binding: NodeId, // This is the variable that is bound to the loop.
+    iterable: NodeId, // This is the iterable that is being looped over.
+    body: NodeId,
+};
+
 // Binary operator node. This is equivalent to the following code:
 // `left + right`
 pub const BinaryOperator = struct {
@@ -192,6 +201,8 @@ pub const Operator = enum {
     // Increment/Decrement operators
     INCREMENT, // '++'
     DECREMENT, // '--'
+
+    RANGE, // '..' (used in for loops)
 
     UNKNOWN,
 };


### PR DESCRIPTION
Adds support for parsing loop, for, and while constructs, including their bodies and relevant components such as iterables, ranges, and conditions.

*Includes tests*