### PR TITLE
Parser and ast nodes for conditionals

### DIFF
--- a/spec/examples/playground.brr
+++ b/spec/examples/playground.brr
@@ -41,7 +41,7 @@ do { ... } while (a < b)
 for (a in b) { ... }
 for (i in 0..1) { ... }
 
-struct MyIterator {`
+struct MyIterator {
     fn next() { 
         return 1; // first invocation
         return null; // last invocation

--- a/src/parse/Parser.zig
+++ b/src/parse/Parser.zig
@@ -226,6 +226,7 @@ pub fn parseAnyStatement(self: *Self) Self.Error!usize {
     if (try self.parseMaybeNativeFunctionDeclStatement()) |stmt| return stmt;
     if (try self.parseMaybeVariableDeclaration()) |stmt| return stmt;
     if (try self.parseMaybeConstantDeclaration()) |stmt| return stmt;
+    if (try self.parseMaybeConditionalStatement()) |stmt| return stmt;
     if (try self.parseMaybeStructStatement()) |stmt| return stmt;
     if (try self.parseMaybeEnumStatement()) |stmt| return stmt;
     if (try self.parseMaybeCallOrAccess()) |stmt| return stmt;
@@ -569,6 +570,8 @@ pub fn parseMaybeNativeFunctionDeclStatement(self: *Self) !?usize {
     });
 }
 
+// Parse function call or member access and return its ID if parsed.
+// For more information please reference `ast.zig -> FunctionCall` and `ast.zig -> MemberAccess` structs.
 pub fn parseMaybeCallOrAccess(self: *Self) !?usize {
     if ((try self.peek()).type != .IDENTIFIER) return null; // This may not be a call or access.
 
@@ -576,6 +579,64 @@ pub fn parseMaybeCallOrAccess(self: *Self) !?usize {
 
     _ = try self.expect(.SEMICOLON);
     return expr;
+}
+
+// Parse conditional statement and return its ID if parsed.
+// For more information please reference `ast.zig -> Conditional` struct.
+pub fn parseMaybeConditionalStatement(self: *Self) !?usize {
+    if (try self.maybe(.KW_IF) == null) return null; // This may not be a conditional statement.
+    return try self.parseConditional(); // This is a recursive function, so it will handle the whole conditional tree.
+}
+
+fn parseConditional(self: *Self) !usize {
+    try self.pushSpan();
+    defer _ = self.popSpan();
+
+    // Check if the next token is `if` keyword (in case of else if to get correct span).
+    if ((try self.peek()).type == .KW_IF) {
+        _ = try self.expect(.KW_IF);
+    }
+
+    _ = try self.expect(.LEFT_PAREN);
+    const condition = try self.parseExpression();
+    _ = try self.expect(.RIGHT_PAREN);
+
+    const body = try self.parseCodeBlock();
+
+    var else_conditional: ?usize = null;
+
+    if (try self.maybe(.KW_ELSE) != null) {
+        if ((try self.peek()).type == .KW_IF) {
+            else_conditional = try self.parseConditional(); // This is a recursive call, so it will handle the whole else-if chain.
+        } else {
+            try self.pushSpan();
+            const else_body = try self.parseCodeBlock();
+
+            else_conditional = try self.tree.addNode(.{
+                .span = self.peekSpan(),
+                .kind = .{
+                    .conditional = .{
+                        .condition = null, // No condition for else block.
+                        .body = else_body,
+                        .else_conditional = null,
+                    },
+                },
+            });
+
+            _ = self.popSpan();
+        }
+    }
+
+    return try self.tree.addNode(.{
+        .span = self.peekSpan(),
+        .kind = .{
+            .conditional = .{
+                .condition = condition,
+                .body = body,
+                .else_conditional = else_conditional,
+            },
+        },
+    });
 }
 
 // Parse block of code.
@@ -1026,6 +1087,53 @@ test "Parse enum Declaration type1" {
             .fields = &.{ 2, 4, 6 },
         } },
     }, enum_node);
+}
+
+test "Parse conditional statement chain" {
+    const source = "if (a) {} else if (b) {} else {}";
+    var lexer: Lexer = .{ .source = source };
+    var parser = Self.init(std.testing.allocator, &lexer);
+    defer parser.deinit(true);
+
+    const if_id = (try parser.parseMaybeConditionalStatement()).?;
+    const if_node = parser.tree.getNodeUnsafe(if_id);
+
+    const expected = ast.Node{
+        .span = .{ .start = 0, .end = source.len },
+        .kind = .{
+            .conditional = .{
+                .condition = 0, // "a"
+                .body = 1, // "{}"
+                .else_conditional = 6, // points to the else-if conditional
+            },
+        },
+    };
+
+    try std.testing.expectEqualDeep(expected, if_node);
+
+    const else_if_node = parser.tree.getNodeUnsafe(6);
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 10, .end = source.len },
+        .kind = .{
+            .conditional = .{
+                .condition = 2, // "b"
+                .body = 3, // "{}"
+                .else_conditional = 5, // final else
+            },
+        },
+    }, else_if_node);
+
+    const else_node = parser.tree.getNodeUnsafe(5);
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 25, .end = source.len },
+        .kind = .{
+            .conditional = .{
+                .condition = null, // else block
+                .body = 4, // "{}"
+                .else_conditional = null,
+            },
+        },
+    }, else_node);
 }
 
 test "Parse code block" {

--- a/src/parse/Parser.zig
+++ b/src/parse/Parser.zig
@@ -783,6 +783,9 @@ pub fn parseAtom(self: *Self) !usize {
 
             return iden;
         },
+        .KW_IF => {
+            return try self.parseInlineConditional();
+        },
         else => return self.reportError(
             "P003",
             "Expected an expression atom.",
@@ -901,6 +904,31 @@ pub fn parseParenthesizedExpr(self: *Self) Self.Error!usize {
         .kind = .{ .expression_group = .{
             .expression = expr,
         } },
+    });
+}
+
+pub fn parseInlineConditional(self: *Self) Self.Error!usize {
+    try self.pushSpan();
+    defer _ = self.popSpan();
+
+    _ = try self.expect(.LEFT_PAREN);
+    const condition = try self.parseExpression();
+    _ = try self.expect(.RIGHT_PAREN);
+
+    const then_expr = try self.parseExpression();
+
+    _ = try self.expect(.KW_ELSE);
+    const else_expr = try self.parseExpression();
+
+    return try self.tree.addNode(.{
+        .span = self.peekSpan(),
+        .kind = .{
+            .inline_conditional = .{
+                .condition = condition,
+                .then_expr = then_expr,
+                .else_expr = else_expr,
+            },
+        },
     });
 }
 
@@ -1134,6 +1162,27 @@ test "Parse conditional statement chain" {
             },
         },
     }, else_node);
+}
+
+test "Parse inline conditional expression" {
+    const source = "if(x) 1 else 2";
+    var lexer: Lexer = .{ .source = source };
+    var parser = Self.init(std.testing.allocator, &lexer);
+    defer parser.deinit(true);
+
+    const expr_id = try parser.parseExpression();
+    const expr_node = parser.tree.getNodeUnsafe(expr_id);
+
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 0, .end = source.len },
+        .kind = .{
+            .inline_conditional = .{
+                .condition = 0, // index of node "x"
+                .then_expr = 1, // index of node 1
+                .else_expr = 2, // index of node 2
+            },
+        },
+    }, expr_node);
 }
 
 test "Parse code block" {

--- a/src/parse/ast.zig
+++ b/src/parse/ast.zig
@@ -36,6 +36,7 @@ pub const NodeKind = union(enum) {
     unary_operator: UnaryOperator,
     assignment: Assignment,
     expression_group: ExpressionGroup,
+    inline_conditional: InlineConditional,
 
     // ---< Special nodes >---
     module: Module,
@@ -172,6 +173,12 @@ pub const Conditional = struct {
     condition: ?NodeId, // This is the condition being checked
     body: NodeId, // This is the body of the conditional
     else_conditional: ?NodeId = null, // This is the optional else if/else conditional
+};
+
+pub const InlineConditional = struct {
+    condition: NodeId, // This is the condition being checked
+    then_expr: NodeId, // This is the expression to evaluate if condition is true
+    else_expr: NodeId, // This is the expression to evaluate if condition is false
 };
 
 // Binary operator node. This is equivalent to the following code:

--- a/src/parse/ast.zig
+++ b/src/parse/ast.zig
@@ -30,7 +30,7 @@ pub const NodeKind = union(enum) {
     field: Field,
     enumField: EnumField,
     anStructField: AnStructField,
-    
+
     // --< Operator nodes >---
     binary_operator: BinaryOperator,
     unary_operator: UnaryOperator,
@@ -49,7 +49,8 @@ pub const NodeKind = union(enum) {
     structure: Struct,
     enumeration: Enum,
     anStruct: AnonymousStruct,
-    
+    conditional: Conditional,
+
     // ---< Expression nodes >---
 };
 
@@ -165,6 +166,12 @@ pub const FunctionCall = struct {
 pub const MemberAccess = struct {
     target: NodeId, // This is the object being accessed
     member: NodeId, // This is the member being accessed
+};
+
+pub const Conditional = struct {
+    condition: ?NodeId, // This is the condition being checked
+    body: NodeId, // This is the body of the conditional
+    else_conditional: ?NodeId = null, // This is the optional else if/else conditional
 };
 
 // Binary operator node. This is equivalent to the following code:


### PR DESCRIPTION
This PR adds support for parsing both statement-level `if (...) { ... } else { ... }` and expression-level `if (...) a else b` conditionals.
Introduces a recursive parsing strategy for chained else if blocks and a new inline_conditional AST node for ternary-style expressions.

Highlights:
- conditional for if statements with optional else branches
- inline_conditional for expressions like if (x) a else b
- Support for nested and chained else if branches
- Tests for both forms of conditionals

