### PR TITLE
Fix structures and enums

### DIFF
--- a/src/parse/Parser.zig
+++ b/src/parse/Parser.zig
@@ -232,7 +232,6 @@ pub fn parseAnyStatement(self: *Self) Self.Error!usize {
     if (try self.parseMaybeConditionalStatement()) |stmt| return stmt;
     if (try self.parseMaybeStructStatement()) |stmt| return stmt;
     if (try self.parseMaybeEnumStatement()) |stmt| return stmt;
-    if (try self.parseMaybeCallOrAccess()) |stmt| return stmt;
 
     // If nothing has returned up to this point, we assume that there
     // is no statement where it should be and panic.
@@ -344,14 +343,14 @@ pub fn parseMaybeStructStatement(self: *Self) !?usize {
         if (try self.maybe(.SEMICOLON) == null and try self.maybe(.COMMA) == null) {
             _ = try self.expect(.RIGHT_CURLY);
             _ = try self.maybe(.SEMICOLON);
-            return try self.tree.addNode(.{ .span = self.peekSpan(), .kind = .{ .structure = .{
+            return try self.tree.addNode(.{ .span = self.peekSpan(), .kind = .{ .struct_def = .{
                 .name = struct_name,
                 .fields = try fields.toOwnedSlice(),
             } } });
         }
         if (try self.maybe(.RIGHT_CURLY) != null) {
             _ = try self.maybe(.SEMICOLON);
-            return try self.tree.addNode(.{ .span = self.peekSpan(), .kind = .{ .structure = .{
+            return try self.tree.addNode(.{ .span = self.peekSpan(), .kind = .{ .struct_def = .{
                 .name = struct_name,
                 .fields = try fields.toOwnedSlice(),
             } } });
@@ -374,7 +373,7 @@ pub fn parseMaybeAnonymStructStatement(self: *Self) !?usize {
         try self.pushSpan();
         _ = try self.expect(.COLON);
         const expression = try self.parseExpression();
-        const field = try self.tree.addNode(.{ .span = self.peekSpan(), .kind = .{ .anStructField = .{
+        const field = try self.tree.addNode(.{ .span = self.peekSpan(), .kind = .{ .struct_field = .{
             .name = field_name,
             .expression = expression,
         } } });
@@ -384,13 +383,13 @@ pub fn parseMaybeAnonymStructStatement(self: *Self) !?usize {
         if (try self.maybe(.SEMICOLON) == null and try self.maybe(.COMMA) == null) {
             _ = try self.expect(.RIGHT_CURLY);
             _ = try self.expect(.SEMICOLON);
-            return try self.tree.addNode(.{ .span = self.peekSpan(), .kind = .{ .anStruct = .{
+            return try self.tree.addNode(.{ .span = self.peekSpan(), .kind = .{ .anon_struct = .{
                 .fields = try fields.toOwnedSlice(),
             } } });
         }
         if (try self.maybe(.RIGHT_CURLY) != null) {
             _ = try self.expect(.SEMICOLON);
-            return try self.tree.addNode(.{ .span = self.peekSpan(), .kind = .{ .anStruct = .{
+            return try self.tree.addNode(.{ .span = self.peekSpan(), .kind = .{ .anon_struct = .{
                 .fields = try fields.toOwnedSlice(),
             } } });
         }
@@ -412,7 +411,7 @@ pub fn parseMaybeEnumStatement(self: *Self) !?usize {
         const field_name = try self.expectIdentifier();
         try self.pushSpan();
 
-        const field = try self.tree.addNode(.{ .span = self.peekSpan(), .kind = .{ .enumField = .{
+        const field = try self.tree.addNode(.{ .span = self.peekSpan(), .kind = .{ .enum_field = .{
             .name = field_name,
         } } });
         try fields.append(field);
@@ -420,14 +419,14 @@ pub fn parseMaybeEnumStatement(self: *Self) !?usize {
         if (try self.maybe(.COMMA) == null) {
             _ = try self.expect(.RIGHT_CURLY);
             _ = try self.maybe(.SEMICOLON);
-            return try self.tree.addNode(.{ .span = self.peekSpan(), .kind = .{ .enumeration = .{
+            return try self.tree.addNode(.{ .span = self.peekSpan(), .kind = .{ .enum_def = .{
                 .name = enum_name,
                 .fields = try fields.toOwnedSlice(),
             } } });
         }
         if (try self.maybe(.RIGHT_CURLY) != null) {
             _ = try self.maybe(.SEMICOLON);
-            return try self.tree.addNode(.{ .span = self.peekSpan(), .kind = .{ .enumeration = .{
+            return try self.tree.addNode(.{ .span = self.peekSpan(), .kind = .{ .enum_def = .{
                 .name = enum_name,
                 .fields = try fields.toOwnedSlice(),
             } } });
@@ -634,17 +633,6 @@ pub fn parseMaybeForLoop(self: *Self) !?usize {
     });
 }
 
-// Parse function call or member access and return its ID if parsed.
-// For more information please reference `ast.zig -> FunctionCall` and `ast.zig -> MemberAccess` structs.
-pub fn parseMaybeCallOrAccess(self: *Self) !?usize {
-    if ((try self.peek()).type != .IDENTIFIER) return null; // This may not be a call or access.
-
-    const expr = try self.parseExpression();
-
-    _ = try self.expect(.SEMICOLON);
-    return expr;
-}
-
 // Parse conditional statement and return its ID if parsed.
 // For more information please reference `ast.zig -> Conditional` struct.
 pub fn parseMaybeConditionalStatement(self: *Self) !?usize {
@@ -830,6 +818,7 @@ pub fn parseAtom(self: *Self) !usize {
         }),
         .BANG, .BITWISE_NOT, .SUBTRACT => try self.parseUnaryOperator(token),
         .LEFT_PAREN => try self.parseParenthesizedExpr(),
+        .LEFT_SQUARE => try self.parseArrayLiteral(),
         .IDENTIFIER => {
             try self.pushSpan();
             defer _ = self.popSpan();
@@ -840,7 +829,7 @@ pub fn parseAtom(self: *Self) !usize {
             });
 
             const next = try self.peek();
-            if (next.type == .INCREMENT or next.type == .DECREMENT or next.type == .DOT or next.type == .LEFT_PAREN) {
+            if (next.type == .INCREMENT or next.type == .DECREMENT or next.type == .DOT or next.type == .LEFT_PAREN or next.type == .LEFT_SQUARE) {
                 // This is a function call or member access (or just incrementation/decrementation).
                 // We will handle it in a separate function.
                 return try self.parsePostfix(iden);
@@ -942,12 +931,22 @@ pub fn parsePostfix(self: *Self, operand: usize) Self.Error!usize {
 
                 expr = try self.tree.addNode(.{
                     .span = self.peekSpan(),
-                    .kind = .{
-                        .function_call = .{
-                            .name = expr,
-                            .arguments = try args.toOwnedSlice(),
-                        },
-                    },
+                    .kind = .{ .function_call = .{
+                        .name = expr,
+                        .arguments = try args.toOwnedSlice(),
+                    } },
+                });
+            },
+            .LEFT_SQUARE => {
+                _ = try self.expect(.LEFT_SQUARE);
+                const index = try self.parseExpression();
+                _ = try self.expect(.RIGHT_SQUARE);
+                expr = try self.tree.addNode(.{
+                    .span = self.peekSpan(),
+                    .kind = .{ .indexed_access = .{
+                        .target = expr,
+                        .index = index,
+                    } },
                 });
             },
             else => break,
@@ -968,6 +967,39 @@ pub fn parseParenthesizedExpr(self: *Self) Self.Error!usize {
         .span = self.peekSpan(),
         .kind = .{ .expression_group = .{
             .expression = expr,
+        } },
+    });
+}
+
+pub fn parseArrayLiteral(self: *Self) Self.Error!usize {
+    try self.pushSpan();
+    defer _ = self.popSpan();
+
+    var spread: ?usize = null;
+    var elements = std.ArrayList(usize).init(self.tree.allocator());
+    errdefer elements.deinit();
+
+    while (try self.maybe(.RIGHT_SQUARE) == null) {
+        if (try self.maybe(.SPREAD) != null) {
+            spread = try self.parseExpression();
+            _ = try self.expect(.RIGHT_SQUARE);
+            break;
+        }
+
+        const expr = try self.parseExpression();
+        try elements.append(expr);
+
+        if (try self.maybe(.COMMA) == null) {
+            _ = try self.expect(.RIGHT_SQUARE); // If we break we need to check this.
+            break;
+        }
+    }
+
+    return try self.tree.addNode(.{
+        .span = self.peekSpan(),
+        .kind = .{ .array_literal = .{
+            .elements = try elements.toOwnedSlice(),
+            .spread = spread,
         } },
     });
 }
@@ -1141,7 +1173,7 @@ test "Parse struct Declaration type" {
     const struct_node = parser.tree.getNodeUnsafe(structure);
     try std.testing.expectEqualDeep(ast.Node{
         .span = .{ .start = 0, .end = 55 },
-        .kind = .{ .structure = .{
+        .kind = .{ .struct_def = .{
             .name = 0,
             .fields = &.{ 2, 4, 9 },
         } },
@@ -1175,7 +1207,7 @@ test "Parse enum Declaration type" {
     const enum_node = parser.tree.getNodeUnsafe(enumeration);
     try std.testing.expectEqualDeep(ast.Node{
         .span = .{ .start = 0, .end = 43 },
-        .kind = .{ .enumeration = .{
+        .kind = .{ .enum_def = .{
             .name = 0,
             .fields = &.{ 2, 4, 6 },
         } },
@@ -1729,13 +1761,59 @@ test "Parse assignment" {
     }, value_assign);
 }
 
+// This test is split up for readability and maintanance purposes.
+test "Parse indexed access postfix expression" {
+    const source = "a[1][2].b[3]";
+    var lexer: Lexer = .{ .source = source };
+    var parser = Self.init(std.testing.allocator, &lexer);
+    defer parser.deinit(true);
+
+    const expr_id = try parser.parseExpression();
+    const expr_node = parser.tree.getNode(expr_id).?;
+
+    // postfix [3] on member_access .b
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 0, .end = 12 },
+        .kind = .{
+            .indexed_access = .{
+                .target = 6,
+                .index = 7,
+            },
+        },
+    }, expr_node);
+
+    // member_access .b applied to indexed_access [2]
+    const member_b = parser.tree.getNode(6).?;
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 0, .end = 9 },
+        .kind = .{
+            .member_access = .{
+                .target = 4, // indexed_access [2]
+                .member = 5, // identifier b
+            },
+        },
+    }, member_b);
+
+    // indexed_access [2] applied to indexed_access [1]
+    const indexed_2 = parser.tree.getNode(4).?;
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 0, .end = 7 },
+        .kind = .{
+            .indexed_access = .{
+                .target = 2, // indexed_access [1]
+                .index = 3, // indexed_access [2]
+            },
+        },
+    }, indexed_2);
+}
+
 test "Parse complex postfix expression" {
     const source = "abc().def.ghi().j++;";
     var lexer: Lexer = .{ .source = source };
     var parser = Self.init(std.testing.allocator, &lexer);
     defer parser.deinit(true);
 
-    const expr_id = (try parser.parseMaybeCallOrAccess()).?;
+    const expr_id = try parser.parseExpression();
     const expr_node = parser.tree.getNode(expr_id).?;
 
     // postfix ++ on member_access ( .j )
@@ -1836,4 +1914,39 @@ test "Parse complex postfix expression" {
         .span = .{ .start = 0, .end = 3 },
         .kind = .{ .identifier = "abc" },
     }, ident_abc);
+}
+
+test "Parse array literal expression" {
+    const source = "[1, 2, ...a] [1, 2,]";
+    var lexer: Lexer = .{ .source = source };
+    var parser = Self.init(std.testing.allocator, &lexer);
+    defer parser.deinit(true);
+
+    const expr_id = try parser.parseExpression();
+    const expr_node = parser.tree.getNode(expr_id).?;
+
+    // Check amount of elements (should be 2) and non-null spread.
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 0, .end = 12 },
+        .kind = .{
+            .array_literal = .{
+                .elements = &.{ 0, 1 },
+                .spread = 2,
+            },
+        },
+    }, expr_node);
+
+    const expr_id_2 = try parser.parseExpression();
+    const expr_node_2 = parser.tree.getNode(expr_id_2).?;
+
+    // Check amount of elements (should be 2) and non-null spread.
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 13, .end = 20 },
+        .kind = .{
+            .array_literal = .{
+                .elements = &.{ 4, 5 },
+                .spread = null,
+            },
+        },
+    }, expr_node_2);
 }

--- a/src/parse/Parser.zig
+++ b/src/parse/Parser.zig
@@ -230,8 +230,8 @@ pub fn parseAnyStatement(self: *Self) Self.Error!usize {
     if (try self.parseMaybeWhileLoop()) |stmt| return stmt;
     if (try self.parseMaybeForLoop()) |stmt| return stmt;
     if (try self.parseMaybeConditionalStatement()) |stmt| return stmt;
-    if (try self.parseMaybeStructStatement()) |stmt| return stmt;
-    if (try self.parseMaybeEnumStatement()) |stmt| return stmt;
+    if (try self.parseMaybeStructDeclStatement()) |stmt| return stmt;
+    if (try self.parseMaybeEnumDeclStatement()) |stmt| return stmt;
 
     // If nothing has returned up to this point, we assume that there
     // is no statement where it should be and panic.
@@ -259,18 +259,6 @@ pub fn parseMaybeVariableDeclaration(self: *Self) !?usize {
     const var_name = try self.expectIdentifier();
     _ = try self.expect(.ASSIGN);
 
-    const anonym_struct = try self.parseMaybeAnonymStructStatement();
-
-    if (anonym_struct != null) {
-        return try self.tree.addNode(.{
-            .span = self.peekSpan(),
-            .kind = .{ .variable = .{
-                .name = var_name,
-                .expression = anonym_struct.?,
-            } },
-        });
-    }
-
     const expression = try self.parseExpression();
     _ = try self.expect(.SEMICOLON);
     return try self.tree.addNode(.{
@@ -291,18 +279,6 @@ pub fn parseMaybeConstantDeclaration(self: *Self) !?usize {
     const const_name = try self.expectIdentifier();
     _ = try self.expect(.ASSIGN);
 
-    const anonym_struct = try self.parseMaybeAnonymStructStatement();
-
-    if (anonym_struct != null) {
-        return try self.tree.addNode(.{
-            .span = self.peekSpan(),
-            .kind = .{ .constant = .{
-                .name = const_name,
-                .expression = anonym_struct.?,
-            } },
-        });
-    }
-
     const expression = try self.parseExpression();
     _ = try self.expect(.SEMICOLON);
     return try self.tree.addNode(.{
@@ -315,124 +291,95 @@ pub fn parseMaybeConstantDeclaration(self: *Self) !?usize {
 }
 
 //parse struct declaration statement and return its ID if parsed
-// For more information please reference `ast.zig -> Structure` struct.
-pub fn parseMaybeStructStatement(self: *Self) !?usize {
+// For more information please reference `ast.zig -> StructDecl` struct.
+pub fn parseMaybeStructDeclStatement(self: *Self) !?usize {
     if (try self.maybe(.KW_STRUCT) == null) return null; // This may not be a struct statement.
-
     try self.pushSpan();
     defer _ = self.popSpan();
+
     const struct_name = try self.expectIdentifier();
-    _ = try self.expect(.LEFT_CURLY);
-    var fields = std.ArrayList(usize).init(self.tree.allocator());
-    errdefer fields.deinit(); // This may return error early.
-
-    while (try self.maybe(.RIGHT_CURLY) == null) {
-        const potential_function = try self.parseMaybeFunctionDefStatement();
-        if (potential_function != null) {
-            try fields.append(potential_function.?);
-        } else {
-            const field_name = try self.expectIdentifier();
-            try self.pushSpan();
-
-            const field = try self.tree.addNode(.{ .span = self.peekSpan(), .kind = .{ .field = .{
-                .name = field_name,
-            } } });
-            try fields.append(field);
-            _ = self.popSpan();
-        }
-        if (try self.maybe(.SEMICOLON) == null and try self.maybe(.COMMA) == null) {
-            _ = try self.expect(.RIGHT_CURLY);
-            _ = try self.maybe(.SEMICOLON);
-            return try self.tree.addNode(.{ .span = self.peekSpan(), .kind = .{ .struct_def = .{
-                .name = struct_name,
-                .fields = try fields.toOwnedSlice(),
-            } } });
-        }
-        if (try self.maybe(.RIGHT_CURLY) != null) {
-            _ = try self.maybe(.SEMICOLON);
-            return try self.tree.addNode(.{ .span = self.peekSpan(), .kind = .{ .struct_def = .{
-                .name = struct_name,
-                .fields = try fields.toOwnedSlice(),
-            } } });
-        }
-    }
-    return error.ExpectedStatement; // maybe sth different here, in theory shouldn't reach
-}
-
-//parse anonymous struct declaration statement and return its ID if parsed
-// For more information please reference `ast.zig -> AnStruct` struct.
-// must be checked before variables not to cause issues with one another, because of the same KW at the start
-pub fn parseMaybeAnonymStructStatement(self: *Self) !?usize {
-    if (try self.maybe(.HASH) == null) return null;
 
     _ = try self.expect(.LEFT_CURLY);
     var fields = std.ArrayList(usize).init(self.tree.allocator());
     errdefer fields.deinit(); // This may return error early.
+    var decls = std.ArrayList(usize).init(self.tree.allocator());
+    errdefer decls.deinit(); // This may return error early.
+
     while (try self.maybe(.RIGHT_CURLY) == null) {
+        // This might be a declaration.
+        if (try self.parseMaybeFunctionDefStatement()) |fn_def_stmt| {
+            try decls.append(fn_def_stmt);
+            continue;
+        }
+
+        // If not, then we assume this is a field
         const field_name = try self.expectIdentifier();
-        try self.pushSpan();
-        _ = try self.expect(.COLON);
-        const expression = try self.parseExpression();
-        const field = try self.tree.addNode(.{ .span = self.peekSpan(), .kind = .{ .struct_field = .{
-            .name = field_name,
-            .expression = expression,
-        } } });
-        try fields.append(field);
-        _ = self.popSpan();
+        try fields.append(field_name);
 
-        if (try self.maybe(.SEMICOLON) == null and try self.maybe(.COMMA) == null) {
+        // Or potentially exit.
+        if (try self.maybe(.COMMA) == null) {
             _ = try self.expect(.RIGHT_CURLY);
-            _ = try self.expect(.SEMICOLON);
-            return try self.tree.addNode(.{ .span = self.peekSpan(), .kind = .{ .anon_struct = .{
-                .fields = try fields.toOwnedSlice(),
-            } } });
-        }
-        if (try self.maybe(.RIGHT_CURLY) != null) {
-            _ = try self.expect(.SEMICOLON);
-            return try self.tree.addNode(.{ .span = self.peekSpan(), .kind = .{ .anon_struct = .{
-                .fields = try fields.toOwnedSlice(),
-            } } });
+            break;
         }
     }
-    return error.ExpectedStatement; // maybe sth different here, in theory shouldn't reach
+
+    // Structures may be followed by semicolon.
+    _ = try self.maybe(.SEMICOLON);
+
+    return try self.tree.addNode(.{
+        .span = self.peekSpan(),
+        .kind = .{ .struct_decl = .{
+            .name = struct_name,
+            .fields = try fields.toOwnedSlice(),
+            .decls = try decls.toOwnedSlice(),
+        } },
+    });
 }
 
 //parse enum declaration statement and return its ID if parsed
-// For more information please reference `ast.zig -> Enum` struct.
-pub fn parseMaybeEnumStatement(self: *Self) !?usize {
-    if (try self.maybe(.KW_ENUM) == null) return null; // This may not be a enum statement.
+// For more information please reference `ast.zig -> EnumDecl` struct.
+pub fn parseMaybeEnumDeclStatement(self: *Self) !?usize {
+    if (try self.maybe(.KW_ENUM) == null) return null; // This may not be an enumeration statement.
     try self.pushSpan();
     defer _ = self.popSpan();
-    const enum_name = try self.expectIdentifier();
-    _ = try self.expect(.LEFT_CURLY);
-    var fields = std.ArrayList(usize).init(self.tree.allocator());
-    errdefer fields.deinit(); // This may return error early.
-    while (try self.maybe(.RIGHT_CURLY) == null) {
-        const field_name = try self.expectIdentifier();
-        try self.pushSpan();
 
-        const field = try self.tree.addNode(.{ .span = self.peekSpan(), .kind = .{ .enum_field = .{
-            .name = field_name,
-        } } });
-        try fields.append(field);
-        _ = self.popSpan();
+    const struct_name = try self.expectIdentifier();
+
+    _ = try self.expect(.LEFT_CURLY);
+    var variants = std.ArrayList(usize).init(self.tree.allocator());
+    errdefer variants.deinit(); // This may return error early.
+    var decls = std.ArrayList(usize).init(self.tree.allocator());
+    errdefer decls.deinit(); // This may return error early.
+
+    while (try self.maybe(.RIGHT_CURLY) == null) {
+        // This might be a declaration.
+        if (try self.parseMaybeFunctionDefStatement()) |fn_def_stmt| {
+            try decls.append(fn_def_stmt);
+            continue;
+        }
+
+        // If not, then we assume this is a field
+        const variant_name = try self.expectIdentifier();
+        try variants.append(variant_name);
+
+        // Or potentially exit.
         if (try self.maybe(.COMMA) == null) {
             _ = try self.expect(.RIGHT_CURLY);
-            _ = try self.maybe(.SEMICOLON);
-            return try self.tree.addNode(.{ .span = self.peekSpan(), .kind = .{ .enum_def = .{
-                .name = enum_name,
-                .fields = try fields.toOwnedSlice(),
-            } } });
-        }
-        if (try self.maybe(.RIGHT_CURLY) != null) {
-            _ = try self.maybe(.SEMICOLON);
-            return try self.tree.addNode(.{ .span = self.peekSpan(), .kind = .{ .enum_def = .{
-                .name = enum_name,
-                .fields = try fields.toOwnedSlice(),
-            } } });
+            break;
         }
     }
-    return error.ExpectedStatement; // maybe sth different here, in theory shouldn't reach
+
+    // Enums may be followed by semicolon.
+    _ = try self.maybe(.SEMICOLON);
+
+    return try self.tree.addNode(.{
+        .span = self.peekSpan(),
+        .kind = .{ .enum_decl = .{
+            .name = struct_name,
+            .variants = try variants.toOwnedSlice(),
+            .decls = try decls.toOwnedSlice(),
+        } },
+    });
 }
 
 // Parse import statement and return its ID if parsed.
@@ -819,6 +766,12 @@ pub fn parseAtom(self: *Self) !usize {
         .BANG, .BITWISE_NOT, .SUBTRACT => try self.parseUnaryOperator(token),
         .LEFT_PAREN => try self.parseParenthesizedExpr(),
         .LEFT_SQUARE => try self.parseArrayLiteral(),
+        .HASH => {
+            try self.pushSpan();
+            defer _ = self.popSpan();
+
+            return try self.parseStructLiteralBody(null);
+        },
         .IDENTIFIER => {
             try self.pushSpan();
             defer _ = self.popSpan();
@@ -829,7 +782,7 @@ pub fn parseAtom(self: *Self) !usize {
             });
 
             const next = try self.peek();
-            if (next.type == .INCREMENT or next.type == .DECREMENT or next.type == .DOT or next.type == .LEFT_PAREN or next.type == .LEFT_SQUARE) {
+            if (next.type == .INCREMENT or next.type == .DECREMENT or next.type == .DOT or next.type == .LEFT_PAREN or next.type == .LEFT_SQUARE or next.type == .LEFT_CURLY) {
                 // This is a function call or member access (or just incrementation/decrementation).
                 // We will handle it in a separate function.
                 return try self.parsePostfix(iden);
@@ -949,11 +902,51 @@ pub fn parsePostfix(self: *Self, operand: usize) Self.Error!usize {
                     } },
                 });
             },
+            .LEFT_CURLY => expr = try self.parseStructLiteralBody(expr),
             else => break,
         }
     }
 
     return expr;
+}
+
+// Parse structure literal body.
+// This assumes that span is pushed and popped by the caller.
+pub fn parseStructLiteralBody(self: *Self, target: ?usize) Self.Error!usize {
+    _ = try self.expect(.LEFT_CURLY);
+
+    var fields = std.ArrayList(usize).init(self.tree.allocator());
+    errdefer fields.deinit();
+
+    while (try self.maybe(.RIGHT_CURLY) == null) {
+        const field_name = try self.expectIdentifier();
+        try self.pushSpan();
+        defer _ = self.popSpan();
+
+        _ = try self.expect(.COLON);
+        const field_value = try self.parseExpression();
+
+        try fields.append(try self.tree.addNode(.{
+            .span = self.peekSpan(),
+            .kind = .{ .field_def = .{
+                .name = field_name,
+                .value = field_value,
+            } },
+        }));
+
+        if (try self.maybe(.COMMA) == null) {
+            _ = try self.expect(.RIGHT_CURLY); // If we break we need to check this.
+            break;
+        }
+    }
+
+    return try self.tree.addNode(.{
+        .span = self.peekSpan(),
+        .kind = .{ .struct_literal = .{
+            .target = target,
+            .fields = try fields.toOwnedSlice(),
+        } },
+    });
 }
 
 pub fn parseParenthesizedExpr(self: *Self) Self.Error!usize {
@@ -1164,54 +1157,82 @@ test "Parse native function declaration statement" {
     }, fn_node);
 }
 
-test "Parse struct Declaration type" {
-    const source = "struct foo {patapim, sahur, fn lorem (helloworld){}, };";
+test "Parse struct declaration statement" {
+    const source =
+        \\struct Foo {
+        \\    patapim, sahur,
+        \\    fn lorem(hello, world) {}
+        \\};
+    ;
     var lexer: Lexer = .{ .source = source };
     var parser = Self.init(std.testing.allocator, &lexer);
     defer parser.deinit(true);
-    const structure = (try parser.parseMaybeStructStatement()).?;
+    const structure = (try parser.parseMaybeStructDeclStatement()).?;
     const struct_node = parser.tree.getNodeUnsafe(structure);
     try std.testing.expectEqualDeep(ast.Node{
-        .span = .{ .start = 0, .end = 55 },
-        .kind = .{ .struct_def = .{
+        .span = .{ .start = 0, .end = 65 },
+        .kind = .{ .struct_decl = .{
             .name = 0,
-            .fields = &.{ 2, 4, 9 },
+            .fields = &.{ 1, 2 },
+            .decls = &.{9},
         } },
     }, struct_node);
 }
 
-test "Parse anonymous struct Declaration type1" {
-    const source = "brr Patapim =  #{age: 32, bankAcc: 12345};";
+test "Parse enum declaration statement" {
+    const source =
+        \\enum Foo {
+        \\    PATAPIM, SAHUR, HELLO_WORLD,
+        \\};
+    ;
     var lexer: Lexer = .{ .source = source };
     var parser = Self.init(std.testing.allocator, &lexer);
     defer parser.deinit(true);
 
-    const structure = (try parser.parseMaybeVariableDeclaration()).?;
-    const struct_node = parser.tree.getNodeUnsafe(structure);
-    try std.testing.expectEqualDeep(ast.Node{
-        .span = .{ .start = 0, .end = 42 },
-        .kind = .{ .variable = .{
-            .name = 0,
-            .expression = 7,
-        } },
-    }, struct_node);
-}
-
-test "Parse enum Declaration type" {
-    const source = "enum myEnum {PATAPIM, SAHUR, HELLO_WORLD,};";
-    var lexer: Lexer = .{ .source = source };
-    var parser = Self.init(std.testing.allocator, &lexer);
-    defer parser.deinit(true);
-
-    const enumeration = (try parser.parseMaybeEnumStatement()).?;
+    const enumeration = (try parser.parseMaybeEnumDeclStatement()).?;
     const enum_node = parser.tree.getNodeUnsafe(enumeration);
     try std.testing.expectEqualDeep(ast.Node{
-        .span = .{ .start = 0, .end = 43 },
-        .kind = .{ .enum_def = .{
+        .span = .{ .start = 0, .end = 46 },
+        .kind = .{ .enum_decl = .{
             .name = 0,
-            .fields = &.{ 2, 4, 6 },
+            .variants = &.{ 1, 2, 3 },
+            .decls = &.{},
         } },
     }, enum_node);
+}
+
+test "Parse struct literal expression" {
+    const source = "Person { name: \"Patapim\", age: 321, }";
+    var lexer: Lexer = .{ .source = source };
+    var parser = Self.init(std.testing.allocator, &lexer);
+    defer parser.deinit(true);
+
+    const literal = try parser.parseExpression();
+    const struct_node = parser.tree.getNodeUnsafe(literal);
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 0, .end = 37 },
+        .kind = .{ .struct_literal = .{
+            .target = 0,
+            .fields = &.{ 3, 6 },
+        } },
+    }, struct_node);
+}
+
+test "Parse anonymous struct literal expression" {
+    const source = "#{ name: \"Patapim\", age: 321, }";
+    var lexer: Lexer = .{ .source = source };
+    var parser = Self.init(std.testing.allocator, &lexer);
+    defer parser.deinit(true);
+
+    const literal = try parser.parseExpression();
+    const struct_node = parser.tree.getNodeUnsafe(literal);
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 0, .end = 31 },
+        .kind = .{ .struct_literal = .{
+            .target = null,
+            .fields = &.{ 2, 5 },
+        } },
+    }, struct_node);
 }
 
 test "Parse simple loop statement" {

--- a/src/parse/ast.zig
+++ b/src/parse/ast.zig
@@ -25,11 +25,9 @@ pub const NodeKind = union(enum) {
     parameter: Parameter,
     native_parameter: NativeParameter,
     code_block: []const NodeId,
-    function_call: FunctionCall,
-    member_access: MemberAccess,
     field: Field,
-    enumField: EnumField,
-    anStructField: AnStructField,
+    enum_field: EnumField,
+    struct_field: StructField,
 
     // --< Operator nodes >---
     binary_operator: BinaryOperator,
@@ -50,12 +48,16 @@ pub const NodeKind = union(enum) {
     loop: Loop,
     while_loop: WhileLoop,
     for_loop: ForLoop,
-    structure: Struct,
-    enumeration: Enum,
-    anStruct: AnonymousStruct,
+    struct_def: Struct,
+    enum_def: Enum,
+    anon_struct: AnonymousStruct,
     conditional: Conditional,
 
     // ---< Expression nodes >---
+    function_call: FunctionCall,
+    member_access: MemberAccess,
+    array_literal: ArrayLiteral,
+    indexed_access: IndexedAccess,
 };
 
 pub const NodeId = usize;
@@ -112,7 +114,7 @@ pub const AnonymousStruct: type = struct {
 };
 
 // Anonymous structure field. Now it holds the field name and expression
-pub const AnStructField: type = struct {
+pub const StructField: type = struct {
     name: NodeId,
     expression: NodeId,
 };
@@ -190,20 +192,32 @@ pub const FunctionCall = struct {
 };
 
 pub const MemberAccess = struct {
-    target: NodeId, // This is the object being accessed
-    member: NodeId, // This is the member being accessed
+    target: NodeId, // This is the object being accessed.
+    member: NodeId, // This is the member being accessed.
+};
+
+// This is equivalent to `[a, b, c, ...d]`.
+pub const ArrayLiteral = struct {
+    elements: []const NodeId,
+    spread: ?NodeId,
+};
+
+// This is `target[index]`.
+pub const IndexedAccess = struct {
+    target: NodeId,
+    index: NodeId,
 };
 
 pub const Conditional = struct {
-    condition: ?NodeId, // This is the condition being checked
-    body: NodeId, // This is the body of the conditional
-    else_conditional: ?NodeId = null, // This is the optional else if/else conditional
+    condition: ?NodeId, // This is the condition being checked.
+    body: NodeId, // This is the body of the conditional.
+    else_conditional: ?NodeId = null, // This is the optional else if/else conditional.
 };
 
 pub const InlineConditional = struct {
-    condition: NodeId, // This is the condition being checked
-    then_expr: NodeId, // This is the expression to evaluate if condition is true
-    else_expr: NodeId, // This is the expression to evaluate if condition is false
+    condition: NodeId, // This is the condition being checked.
+    then_expr: NodeId, // This is the expression to evaluate if condition is true.
+    else_expr: NodeId, // This is the expression to evaluate if condition is false.
 };
 
 // Binary operator node. This is equivalent to the following code:

--- a/src/parse/ast.zig
+++ b/src/parse/ast.zig
@@ -25,9 +25,7 @@ pub const NodeKind = union(enum) {
     parameter: Parameter,
     native_parameter: NativeParameter,
     code_block: []const NodeId,
-    field: Field,
-    enum_field: EnumField,
-    struct_field: StructField,
+    field_def: FieldDef,
 
     // --< Operator nodes >---
     binary_operator: BinaryOperator,
@@ -48,16 +46,17 @@ pub const NodeKind = union(enum) {
     loop: Loop,
     while_loop: WhileLoop,
     for_loop: ForLoop,
-    struct_def: Struct,
-    enum_def: Enum,
-    anon_struct: AnonymousStruct,
+    struct_decl: StructDecl,
+    enum_decl: EnumDecl,
     conditional: Conditional,
+    expr_stmt: NodeId, // This is special statement wrapper for expressions as statements.
 
     // ---< Expression nodes >---
     function_call: FunctionCall,
     member_access: MemberAccess,
     array_literal: ArrayLiteral,
     indexed_access: IndexedAccess,
+    struct_literal: StructLiteral,
 };
 
 pub const NodeId = usize;
@@ -82,53 +81,46 @@ pub const Import = struct {
 };
 
 // Variable declaration. This is equivalent to the following code:
-// brr [var name] = [expression];
+// `brr [var name] = [expression];`
 pub const Variable = struct {
     name: NodeId,
     expression: NodeId,
 };
 
 //Const declaration. This is equivalent to the following code:
-//const [name] = [expression];
+//`const [name] = [expression];`
 pub const Const = struct {
     name: NodeId,
     expression: NodeId,
 };
 
 // Structure definition. This is equivalent to the following code:
-// struct [name] { field1, field2, ... }`
-pub const Struct = struct {
+// `struct [name] { field1, field2, ... }`
+pub const StructDecl = struct {
     name: NodeId,
     fields: []const NodeId, // This is a list of fields.
-};
-
-// Structure field. Now it only holds the field name
-pub const Field: type = struct {
-    name: NodeId,
-};
-
-//Anonymous structure definition. This is equivalent to the following code:
-//  brr [name] = #{ field1, field2, ... }`
-pub const AnonymousStruct: type = struct {
-    fields: []const NodeId,
-};
-
-// Anonymous structure field. Now it holds the field name and expression
-pub const StructField: type = struct {
-    name: NodeId,
-    expression: NodeId,
+    decls: []const NodeId, // This is a list of declarations.
 };
 
 // Enum definition. This is equivalent to following code:
-// enum [name] {field1, field2, ...}
-pub const Enum = struct {
+// `enum [name] {field1, field2, ...}`
+pub const EnumDecl = struct {
     name: NodeId,
-    fields: []const NodeId, // This is a list of fields.
+    variants: []const NodeId, // This is a list of enumeration variants.
+    decls: []const NodeId, // This is a list of declarations.
 };
 
-// enum field. Now it only holds the field name
-pub const EnumField: type = struct {
+// Field for structure literal.
+pub const FieldDef = struct {
     name: NodeId,
+    value: NodeId,
+};
+
+// Structure literal. This is equivalent to the following code:
+// `<target> { field1: value, field2: value }`
+pub const StructLiteral = struct {
+    target: ?NodeId, // If this is null, this is anonymous.
+    fields: []const NodeId,
 };
 
 // Function definition. This is equivalent to the following code:


### PR DESCRIPTION
This is kind of a big PR. It reimplements parsing for structures and enumerations to account for edge cases and make code more readable.
There are also new features like structure literals (now being parsed as expressions instead of separate thing in variable declarations).
AST structure is changed to account for our naming convention, as well as making it a bit tidier.

**In order to keep git history clean #43 should be merged first**