### PR TITLE
Parse break and continue statements

### DIFF
--- a/spec/examples/playground.brr
+++ b/spec/examples/playground.brr
@@ -106,3 +106,6 @@ brr anonStruct = #{
 
 // Lambda/Closures 
 (a, b)  -> { ... }
+
+// switch
+TODO

--- a/src/parse/Parser.zig
+++ b/src/parse/Parser.zig
@@ -232,6 +232,8 @@ pub fn parseAnyStatement(self: *Self) Self.Error!usize {
     if (try self.parseMaybeConditionalStatement()) |stmt| return stmt;
     if (try self.parseMaybeStructDeclStatement()) |stmt| return stmt;
     if (try self.parseMaybeEnumDeclStatement()) |stmt| return stmt;
+    if (try self.parseMaybeBreakStatement()) |stmt| return stmt;
+    if (try self.parseMaybeContinueStatement()) |stmt| return stmt;
 
     // If nothing has returned up to this point, we assume that there
     // is no statement where it should be and panic.
@@ -577,6 +579,32 @@ pub fn parseMaybeForLoop(self: *Self) !?usize {
             .iterable = iterable,
             .body = body,
         } },
+    });
+}
+
+// Parse maybe break statement and return its ID if parsed.
+pub fn parseMaybeBreakStatement(self: *Self) !?usize {
+    if (try self.maybe(.KW_BREAK) == null) return null; // This may not be a break statement.
+    try self.pushSpan();
+    defer _ = self.popSpan();
+
+    _ = try self.expect(.SEMICOLON);
+    return try self.tree.addNode(.{
+        .span = self.peekSpan(),
+        .kind = .{ .break_stmt = {} },
+    });
+}
+
+// Parse maybe continue statement and return its ID if parsed.
+pub fn parseMaybeContinueStatement(self: *Self) !?usize {
+    if (try self.maybe(.KW_CONTINUE) == null) return null; // This may not be a continue statement.
+    try self.pushSpan();
+    defer _ = self.popSpan();
+
+    _ = try self.expect(.SEMICOLON);
+    return try self.tree.addNode(.{
+        .span = self.peekSpan(),
+        .kind = .{ .continue_stmt = {} },
     });
 }
 
@@ -1296,6 +1324,33 @@ test "Parse simple for loop statement" {
             },
         },
     }, expr_node);
+}
+
+test "Parse break statement" {
+    const source = "break;continue;";
+    var lexer: Lexer = .{ .source = source };
+    var parser = Self.init(std.testing.allocator, &lexer);
+    defer parser.deinit(true);
+
+    const break_id = (try parser.parseMaybeBreakStatement()).?;
+    const break_node = parser.tree.getNodeUnsafe(break_id);
+
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 0, .end = 6 },
+        .kind = .{
+            .break_stmt = {},
+        },
+    }, break_node);
+
+    const continue_id = (try parser.parseMaybeContinueStatement()).?;
+    const continue_node = parser.tree.getNodeUnsafe(continue_id);
+
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 6, .end = source.len },
+        .kind = .{
+            .continue_stmt = {},
+        },
+    }, continue_node);
 }
 
 test "Parse conditional statement chain" {

--- a/src/parse/ast.zig
+++ b/src/parse/ast.zig
@@ -50,6 +50,8 @@ pub const NodeKind = union(enum) {
     enum_decl: EnumDecl,
     conditional: Conditional,
     expr_stmt: NodeId, // This is special statement wrapper for expressions as statements.
+    break_stmt: void,
+    continue_stmt: void,
 
     // ---< Expression nodes >---
     function_call: FunctionCall,


### PR DESCRIPTION
Add parsing support for `break` and `continue` statements, creating corresponding AST nodes to handle loop control flow correctly.








