### PR TITLE
Parse return statement

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -21,7 +21,10 @@ pub fn main() !void {
         \\const y = [1, 2, ... 3..10];
         \\struct Person {
         \\    name, age,
-        \\    fn greet() { print("Hello, " + this.name + "!"); }
+        \\    fn greet() { 
+        \\      print("Hello, " + this.name + "!"); 
+        \\      return this.age;
+        \\    }
         \\}
         \\enum E { A, B, C }
         \\if (a < b) { print(a); } else if (b < a) { print(b); } else {}

--- a/src/parse/Parser.zig
+++ b/src/parse/Parser.zig
@@ -232,6 +232,7 @@ pub fn parseAnyStatement(self: *Self) Self.Error!usize {
     if (try self.parseMaybeConditionalStatement()) |stmt| return stmt;
     if (try self.parseMaybeStructDeclStatement()) |stmt| return stmt;
     if (try self.parseMaybeEnumDeclStatement()) |stmt| return stmt;
+    if (try self.parseMaybeReturnStatement()) |stmt| return stmt;
 
     // If nothing has returned up to this point, we assume that there
     // is no statement where it should be and panic.
@@ -516,6 +517,30 @@ pub fn parseMaybeNativeFunctionDeclStatement(self: *Self) !?usize {
             .abi = abi_node,
             .name = fn_name,
             .parameters = try fn_parameters.toOwnedSlice(),
+        } },
+    });
+}
+
+pub fn parseMaybeReturnStatement(self: *Self) !?usize {
+    if (try self.maybe(.KW_RETURN) == null) return null; // This may not be a return statement.
+    try self.pushSpan();
+    defer _ = self.popSpan();
+
+    var expression: ?usize = null;
+
+    if ((try self.peek()).type != .SEMICOLON) {
+        // If we do not have semicolon, we expect an expression.
+        expression = try self.parseExpression();
+        _ = try self.expect(.SEMICOLON);
+    } else {
+        // If we have semicolon, we do not return anything.
+        _ = try self.expect(.SEMICOLON);
+    }
+
+    return try self.tree.addNode(.{
+        .span = self.peekSpan(),
+        .kind = .{ .return_stmt = .{
+            .value = expression,
         } },
     });
 }
@@ -1103,6 +1128,33 @@ test "Parse function definition statement" {
             .body = 5,
         } },
     }, fn_node);
+}
+
+test "Parse return statement" {
+    const source = "return 42; return;";
+    var lexer: Lexer = .{ .source = source };
+    var parser = Self.init(std.testing.allocator, &lexer);
+    defer parser.deinit(true);
+
+    const return_value_id = (try parser.parseMaybeReturnStatement()).?;
+    const return_value_node = parser.tree.getNodeUnsafe(return_value_id);
+
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 0, .end = 10 },
+        .kind = .{ .return_stmt = .{
+            .value = 0,
+        } },
+    }, return_value_node);
+
+    const return_id = (try parser.parseMaybeReturnStatement()).?;
+    const return_node = parser.tree.getNodeUnsafe(return_id);
+
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 11, .end = 18 },
+        .kind = .{ .return_stmt = .{
+            .value = null,
+        } },
+    }, return_node);
 }
 
 test "Parse variable declaration statement" {

--- a/src/parse/Parser.zig
+++ b/src/parse/Parser.zig
@@ -544,12 +544,9 @@ pub fn parseMaybeReturnStatement(self: *Self) !?usize {
 
     var expression: ?usize = null;
 
-    if ((try self.peek()).type != .SEMICOLON) {
+    if (try self.maybe(.SEMICOLON) == null) {
         // If we do not have semicolon, we expect an expression.
         expression = try self.parseExpression();
-        _ = try self.expect(.SEMICOLON);
-    } else {
-        // If we have semicolon, we do not return anything.
         _ = try self.expect(.SEMICOLON);
     }
 

--- a/src/parse/ast.zig
+++ b/src/parse/ast.zig
@@ -41,6 +41,7 @@ pub const NodeKind = union(enum) {
     import: Import,
     function_def: FunctionDef,
     native_function_decl: NativeFunctionDecl,
+    return_stmt: ReturnStatement,
     variable: Variable,
     constant: Const,
     loop: Loop,
@@ -154,6 +155,12 @@ pub const NativeFunctionDecl = struct {
 pub const NativeParameter = struct {
     name: NodeId,
     type: ?NodeId,
+};
+
+// This is a return statement. This is equivalent to the following code:
+// `return [expression];`
+pub const ReturnStatement = struct {
+    value: ?NodeId, // This is the expression being returned.
 };
 
 // Loop node. This is equivalent to the following code:

--- a/src/utility/AstPrettyPrinter.zig
+++ b/src/utility/AstPrettyPrinter.zig
@@ -165,6 +165,19 @@ pub fn visitNativeFunctionDecl(self: *Self, tree: *const ast.Tree, span: common.
     try self.writer.writeAll(")\n");
 }
 
+pub fn visitReturnStmt(self: *Self, tree: *const ast.Tree, span: common.Span, ret: ast.ReturnStatement, visitee: anytype) !void {
+    _ = visitee;
+
+    try self.writeIndent();
+    try self.writer.print("{}return", .{ansi.Style{ .foreground = .{ .basic = .yellow } }});
+    try self.writeSpan(span);
+    if (ret.value) |value| {
+        try self.writer.writeByte(' ');
+        try self.accept(tree, value);
+    }
+    try self.writer.writeByte('\n');
+}
+
 pub fn visitNativeParameter(self: *Self, tree: *const ast.Tree, span: common.Span, param: ast.NativeParameter, visitee: anytype) !void {
     _ = span;
     _ = visitee;
@@ -298,6 +311,7 @@ pub fn visitEnumDecl(self: *Self, tree: *const ast.Tree, span: common.Span, decl
     try self.writeIndent();
     try self.writer.writeAll("}\n");
 }
+
 pub fn visitExprStmt(self: *Self, tree: *const ast.Tree, span: common.Span, expr: usize, visitee: anytype) !void {
     _ = visitee;
     _ = span;


### PR DESCRIPTION
Add support for parsing `return` statements in the language syntax. This includes handling both `return;` and `return <expression>;` forms, and creating the appropriate AST nodes to represent them.