### PR TITLE
Implement assignments operators other then

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Patapim ma służyć przede wszystkim jako:
 
 ## 🚧 Status projektu
 
-- **Etap:** Koncepcyjny
+- **Etap:** Projekt jest na wczesnym etapie rozwoju — skupiamy się na tworzeniu fundamentów języka oraz podstawowej architektury interpretera i parsera.
 
 ---
 

--- a/src/Lexer.zig
+++ b/src/Lexer.zig
@@ -75,6 +75,8 @@ pub const KEYWORD_MAP: std.StaticStringMap(TokenType) = .initComptime(.{
     .{ "const", .KW_CONST },
     .{ "native", .KW_NATIVE },
     .{ "iserror", .KW_ISERROR },
+    .{ "and", .LOGICAL_AND },
+    .{ "or", .LOGICAL_OR },
 });
 
 pub const TokenType = enum {

--- a/src/interpreter/Interpreter.zig
+++ b/src/interpreter/Interpreter.zig
@@ -277,24 +277,7 @@ pub fn evalAssignment(self: *Self, tree: *const ast.Tree, node: ast.Node, env: *
 
     const value = try self.evalNode(tree, assignment.value, env);
 
-    // Set the value in the environment.
-    switch (assignment.operator) {
-        .ASSIGN => try env.set(name, value),
-        // TODO: Implement other assignment operators.
-        else => return self.reportError(
-            "I003",
-            "Unsupported assignment operator: {s}",
-            .{@tagName(assignment.operator)},
-            error.UnsupportedNodeType,
-            .{
-                .labels = &.{.{
-                    .color = .{ .basic = .red },
-                    .span = node.span.asReportz(),
-                    .message = "Unsupported assignment operator.",
-                }},
-            },
-        ),
-    }
+    try env.set(name, value);
 
     // Return the assigned value.
     return value;

--- a/src/main.zig
+++ b/src/main.zig
@@ -65,6 +65,7 @@ pub fn main() !void {
         \\}
         \\brr xyz = if(abc == 3) 10 else 20;
         \\const pol = abc + def + ghi + xyz;
+        \\def += abc;
     ;
 
     var lexer: patapim.Lexer = .{ .source = source };

--- a/src/parse/Parser.zig
+++ b/src/parse/Parser.zig
@@ -755,23 +755,47 @@ pub fn parseBinaryExpression(self: *Self, precedence: u8) !usize {
             },
             .kind = switch (nextPrecedence) {
                 // Assignments:
-                1 => .{
-                    .assignment = .{
-                        .operator = switch (next.type) {
-                            .ASSIGN => .ASSIGN,
-                            .ADD_ASSIGN => .ADD_ASSIGN,
-                            .SUB_ASSIGN => .SUB_ASSIGN,
-                            .MUL_ASSIGN => .MUL_ASSIGN,
-                            .DIV_ASSIGN => .DIV_ASSIGN,
-                            .MOD_ASSIGN => .MOD_ASSIGN,
-                            .BITWISE_AND_ASSIGN => .BITWISE_AND_ASSIGN,
-                            .BITWISE_OR_ASSIGN => .BITWISE_OR_ASSIGN,
-                            .BITWISE_XOR_ASSIGN => .BITWISE_XOR_ASSIGN,
-                            else => unreachable,
+                1 => blk: {
+                    var assign_op: ?ast.Operator = null;
+
+                    switch (next.type) {
+                        .ASSIGN => break :blk .{
+                            .assignment = .{
+                                .target = left,
+                                .value = right,
+                            },
                         },
-                        .target = left,
-                        .value = right,
-                    },
+                        .ADD_ASSIGN => assign_op = .ADD,
+                        .SUB_ASSIGN => assign_op = .SUBTRACT,
+                        .MUL_ASSIGN => assign_op = .MULTIPLY,
+                        .DIV_ASSIGN => assign_op = .DIVIDE,
+                        .MOD_ASSIGN => assign_op = .MODULO,
+                        .BITWISE_AND_ASSIGN => assign_op = .BITWISE_AND,
+                        .BITWISE_OR_ASSIGN => assign_op = .BITWISE_OR,
+                        .BITWISE_XOR_ASSIGN => assign_op = .BITWISE_XOR,
+                        else => return error.UnexpectedToken,
+                    }
+
+                    const binary_expr_node = try self.tree.addNode(.{
+                        .span = .{
+                            .start = left_node.span.start,
+                            .end = right_node.span.end,
+                        },
+                        .kind = .{
+                            .binary_operator = .{
+                                .left = left,
+                                .operator = assign_op.?,
+                                .right = right,
+                            },
+                        },
+                    });
+
+                    break :blk .{
+                        .assignment = .{
+                            .target = left,
+                            .value = binary_expr_node,
+                        },
+                    };
                 },
                 else => .{
                     .binary_operator = .{
@@ -1941,9 +1965,8 @@ test "Parse assignment" {
         .span = .{ .start = 0, .end = 10 },
         .kind = .{
             .assignment = .{
-                .operator = .ADD_ASSIGN,
                 .target = 1,
-                .value = 5,
+                .value = 6,
             },
         },
     }, expr_node);
@@ -1955,18 +1978,30 @@ test "Parse assignment" {
         .kind = .{ .identifier = "a" },
     }, target_add_assign);
 
-    // value of '+=': assignment '='
-    const value_add_assign = parser.tree.getNode(5).?;
+    // value of '+=': assignment '=' and later '+'
+    const value_add_assign = parser.tree.getNode(6).?;
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 0, .end = 10 },
+        .kind = .{
+            .binary_operator = .{
+                .left = 1,
+                .operator = .ADD,
+                .right = 5,
+            },
+        },
+    }, value_add_assign);
+
+    // Left operand of '+='
+    const value_add_assign_expr = parser.tree.getNode(5).?;
     try std.testing.expectEqualDeep(ast.Node{
         .span = .{ .start = 5, .end = 10 },
         .kind = .{
             .assignment = .{
-                .operator = .ASSIGN,
                 .target = 3,
                 .value = 4,
             },
         },
-    }, value_add_assign);
+    }, value_add_assign_expr);
 
     // target of '=': identifier 'b'
     const target_assign = parser.tree.getNode(2).?;

--- a/src/parse/ast.zig
+++ b/src/parse/ast.zig
@@ -248,7 +248,6 @@ pub const UnaryOperator = struct {
 // `variable_name = value`
 pub const Assignment = struct {
     target: NodeId,
-    operator: AssignmentOperator,
     value: NodeId, // Expression
 };
 
@@ -297,22 +296,6 @@ pub const Operator = enum {
     DECREMENT, // '--'
 
     RANGE, // '..' (used in for loops)
-
-    UNKNOWN,
-};
-
-// Assigment operator.
-// This is used to represent the operator itself, and not the whole expression.
-pub const AssignmentOperator = enum {
-    ASSIGN, // '='
-    ADD_ASSIGN, // '+='
-    SUB_ASSIGN, // '-='
-    MUL_ASSIGN, // '*='
-    DIV_ASSIGN, // '/='
-    MOD_ASSIGN, // '%='
-    BITWISE_AND_ASSIGN, // '&='
-    BITWISE_OR_ASSIGN, // '|='
-    BITWISE_XOR_ASSIGN, // '^='
 
     UNKNOWN,
 };

--- a/src/utility/AstPrettyPrinter.zig
+++ b/src/utility/AstPrettyPrinter.zig
@@ -484,9 +484,9 @@ pub fn visitAssignment(self: *Self, tree: *const ast.Tree, span: common.Span, ex
 
     try self.writer.writeByte('(');
     try self.accept(tree, expr.target);
-    try self.writer.print(" {}{s}{} ", .{
+    try self.writer.print(" {}{}{} ", .{
         ansi.Style{ .foreground = .{ .basic = .bright_magenta } },
-        @tagName(expr.operator),
+        try self.writer.writeByte('='),
         ansi.Style{ .modifiers = .{ .reset = true } },
     });
     try self.accept(tree, expr.value);


### PR DESCRIPTION
## ➕ Implement Additional Assignment Operators and Improve Parsing Strategy

This PR introduces support for compound assignment operators and improves how such expressions are parsed and evaluated.

### ✨ Changes
- Added support for the following assignment operators:
  - `+=`, `-=`, `*=`, `/=`, `%=`
  - Bitwise operators: `&=`, `|=`, `^=`
- These are now desugared directly in the **parser**, e.g.:
  ```plaintext
  x += 2  →  x = x + 2
  ```
This approach simplifies the interpreter and makes the behavior easier to reason about.

### 🔧 Design Decision
Instead of evaluating compound assignments dynamically in the interpreter, I decided it's better to transform them during parsing. This keeps the interpreter cleaner and shifts responsibility for expression desugaring to a single point.

### 🧠 Extras
Introduced and and or as language-level aliases for && and ||, making the language more expressive and accessible.