### PR TITLE
Implement closures in parser

### DIFF
--- a/src/parse/Parser.zig
+++ b/src/parse/Parser.zig
@@ -1022,6 +1022,29 @@ pub fn parseParenthesizedExpr(self: *Self) Self.Error!usize {
     try self.pushSpan();
     defer _ = self.popSpan();
 
+    if (try self.maybe(.RIGHT_PAREN) != null) {
+        if (try self.parseMaybeClosure(&.{})) |closure| {
+            // If we parsed a closure, we return it instead of an empty expression group.
+            return closure;
+        }
+
+        const token = try self.peek();
+
+        return self.reportError(
+            "P004",
+            "Not expected empty parentheses.",
+            .{},
+            error.UnexpectedToken,
+            .{
+                .labels = &.{.{
+                    .color = .{ .basic = .magenta },
+                    .span = token.span.asReportz(),
+                    .message = "Found empty parentheses.",
+                }},
+            },
+        );
+    }
+
     const expr = try self.parseExpression();
 
     if (try self.maybe(.COMMA) != null) {
@@ -1059,9 +1082,28 @@ pub fn parseTuple(self: *Self, first_expression: usize) Self.Error!usize {
         }
     }
 
+    if (try self.parseMaybeClosure(expressions.items)) |closure| {
+        // If we parsed a closure, we return it instead of a tuple.
+        return closure;
+    }
+
     return self.tree.addNode(.{ .span = self.peekSpan(), .kind = .{ .tuple = .{
         .expressions = try expressions.toOwnedSlice(),
     } } });
+}
+
+pub fn parseMaybeClosure(self: *Self, parameters: []usize) !?usize {
+    if (try self.maybe(.ARROW) == null) return null; // This may not be a closure.
+
+    const body = try self.parseCodeBlock();
+
+    return try self.tree.addNode(.{
+        .span = self.peekSpan(),
+        .kind = .{ .closure = .{
+            .parameters = parameters,
+            .body = body,
+        } },
+    });
 }
 
 pub fn parseArrayLiteral(self: *Self) Self.Error!usize {
@@ -1376,6 +1418,7 @@ test "Parse tuples (multiple)" {
         } },
     }, tuple_node);
 }
+
 test "Parse tuples (multiple with inside tuple)" {
     const source = "(a,b,(c,d),)";
     var lexer: Lexer = .{ .source = source };
@@ -1390,6 +1433,40 @@ test "Parse tuples (multiple with inside tuple)" {
             .expressions = &.{ 1, 3, 8 },
         } },
     }, tuple_node);
+}
+
+test "Parse no-parameter closure" {
+    const source = "() -> { return 10; }";
+    var lexer: Lexer = .{ .source = source };
+    var parser = Self.init(std.testing.allocator, &lexer);
+    defer parser.deinit(true);
+
+    const closure = try parser.parseExpression();
+    const closure_node = parser.tree.getNodeUnsafe(closure);
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 0, .end = 20 },
+        .kind = .{ .closure = .{
+            .parameters = &.{},
+            .body = 2,
+        } },
+    }, closure_node);
+}
+
+test "Parse closure with parameters" {
+    const source = "(a, b) -> { return a + b; }";
+    var lexer: Lexer = .{ .source = source };
+    var parser = Self.init(std.testing.allocator, &lexer);
+    defer parser.deinit(true);
+
+    const closure = try parser.parseExpression();
+    const closure_node = parser.tree.getNodeUnsafe(closure);
+    try std.testing.expectEqualDeep(ast.Node{
+        .span = .{ .start = 0, .end = 27 },
+        .kind = .{ .closure = .{
+            .parameters = &.{ 1, 3 },
+            .body = 10,
+        } },
+    }, closure_node);
 }
 
 test "Parse anonymous struct literal expression" {

--- a/src/parse/ast.zig
+++ b/src/parse/ast.zig
@@ -34,6 +34,7 @@ pub const NodeKind = union(enum) {
     assignment: Assignment,
     expression_group: ExpressionGroup,
     inline_conditional: InlineConditional,
+    closure: Closure,
 
     // ---< Special nodes >---
     module: Module,
@@ -250,6 +251,11 @@ pub const Assignment = struct {
     target: NodeId,
     operator: AssignmentOperator,
     value: NodeId, // Expression
+};
+
+pub const Closure = struct {
+    parameters: []const NodeId,
+    body: NodeId,
 };
 
 // Expression group node. This is used to group expressions together.

--- a/src/utility/AstPrettyPrinter.zig
+++ b/src/utility/AstPrettyPrinter.zig
@@ -343,6 +343,23 @@ pub fn visitFunctionCall(self: *Self, tree: *const ast.Tree, span: common.Span, 
     try self.writer.writeByte(')');
 }
 
+pub fn visitClosure(self: *Self, tree: *const ast.Tree, span: common.Span, closure: ast.Closure, visitee: anytype) !void {
+    _ = visitee;
+    _ = span;
+
+    try self.writer.writeByte('(');
+    for (closure.parameters) |param| {
+        try self.accept(tree, param);
+        try self.writer.writeAll(", ");
+    }
+    try self.writer.writeAll(") -> {\n");
+    self.indent += 4;
+    try self.accept(tree, closure.body);
+    self.indent -= 4;
+    try self.writeIndent();
+    try self.writer.writeAll("}");
+}
+
 pub fn visitMemberAccess(self: *Self, tree: *const ast.Tree, span: common.Span, access: ast.MemberAccess, visitee: anytype) !void {
     _ = visitee;
     _ = span;


### PR DESCRIPTION
## Description

- Added parsing support for inline lambda expressions with parameter lists and block bodies, e.g. `(x, y) -> { ... }`.
- Differentiated closures from tuples by requiring the arrow `->` token after the parameter list.
- Updated AST to include a `Closure` node storing parameters and body.
- Enabled nesting of closures and support for zero or multiple parameters.
- Prepared groundwork for closure capture and runtime support in the interpreter.