### PR TITLE
feat : added support for while and loop loops in interpreter

### DIFF
--- a/src/interpreter/Interpreter.zig
+++ b/src/interpreter/Interpreter.zig
@@ -18,6 +18,14 @@ diagnostic_log: std.ArrayList(reportz.reports.Diagnostic),
 pub const Self = @This();
 const LOG = std.log.scoped(.interpreter);
 
+pub const FlowControl = enum {
+    NOTHING,
+    BREAK,
+    CONTINUE,
+};
+
+pub var flow_control: FlowControl = .NOTHING;
+
 // Initializes the interpreter with the given AST tree and global environment.
 // The global environment is used to store variables and their values.
 pub fn init(allocator: std.mem.Allocator, tree: *const ast.Tree) !Self {
@@ -119,6 +127,10 @@ pub fn interpret(self: *Self, root_id: usize) !void {
 // It dispatches the evaluation to the appropriate handler based on the node type.
 // The node can be a module, code block, expression, or variable declaration.
 pub fn evalNode(self: *Self, tree: *const ast.Tree, node_id: usize, env: *runtime.Environment) Self.Error!runtime.RuntimeValue {
+    if (flow_control != .NOTHING) {
+        return .Void;
+    }
+
     const node = tree.getNode(node_id) orelse return self.reportError(
         "I001",
         "Node with ID {} does not exist.",
@@ -232,6 +244,16 @@ pub fn evalNode(self: *Self, tree: *const ast.Tree, node_id: usize, env: *runtim
             return value;
         },
         .conditional => return try self.evalConditional(tree, node, env),
+        .loop => return try self.evalLoop(tree, node, env),
+        .while_loop => return try self.evalWhile(tree, node, env),
+        .break_stmt => {
+            flow_control = .BREAK;
+            return runtime.RuntimeValue.Void;
+        },
+        .continue_stmt => {
+            flow_control = .CONTINUE;
+            return runtime.RuntimeValue.Void;
+        },
         .inline_conditional => return try self.evalInlineConditional(tree, node, env),
         else => {
             LOG.warn("Unsupported node type: {s}", .{@tagName(node.kind)});
@@ -656,6 +678,50 @@ pub fn evalConditional(self: *Self, tree: *const ast.Tree, node: ast.Node, env: 
 
     // If there is no 'else if' or 'else' block, return Void.
     return runtime.RuntimeValue.Void;
+}
+
+pub fn checkBreak() bool {
+    if (flow_control == .BREAK) {
+        flow_control = .NOTHING;
+        return true;
+    } else {
+        flow_control = .NOTHING;
+        return false;
+    }
+}
+
+pub fn evalLoop(self: *Self, tree: *const ast.Tree, node: ast.Node, env: *runtime.Environment) Self.Error!runtime.RuntimeValue {
+    const loop = node.kind.loop;
+
+    var return_value: runtime.RuntimeValue = runtime.RuntimeValue.Void;
+
+    while (true) {
+        if (checkBreak())
+            break;
+
+        return_value = try self.evalNode(tree, loop.body, env);
+    }
+    return return_value;
+}
+
+pub fn evalWhile(self: *Self, tree: *const ast.Tree, node: ast.Node, env: *runtime.Environment) Self.Error!runtime.RuntimeValue {
+    const while_loop = node.kind.while_loop;
+
+    var condition_value = try self.evalNode(tree, while_loop.condition, env);
+    var condition_bool = isTruthy(condition_value);
+    var return_value: runtime.RuntimeValue = runtime.RuntimeValue.Void;
+
+    while (condition_bool) {
+        if (checkBreak())
+            break;
+
+        return_value = try self.evalNode(tree, while_loop.body, env);
+
+        condition_value = try self.evalNode(tree, while_loop.condition, env);
+        condition_bool = isTruthy(condition_value);
+    }
+
+    return return_value;
 }
 
 pub fn evalInlineConditional(self: *Self, tree: *const ast.Tree, node: ast.Node, env: *runtime.Environment) Self.Error!runtime.RuntimeValue {

--- a/src/main.zig
+++ b/src/main.zig
@@ -63,8 +63,32 @@ pub fn main() !void {
         \\    brr x = 3;
         \\    abc = x;
         \\}
+        \\
+        \\
         \\brr xyz = if(abc == 3) 10 else 20;
         \\const pol = abc + def + ghi + xyz;
+        \\brr i = 0;
+        \\while(i<10){
+        \\i = i+1;
+        \\}
+        \\brr j = 2;
+        \\brr even = 0;
+        \\loop
+        \\{
+        \\  loop
+        \\  {
+        \\      j = j +1;
+        \\      if(j >= 10)
+        \\       {
+        \\          break;
+        \\       }
+        \\  }
+        \\  even = even + 1;
+        \\  if(even == 15)
+        \\  {
+        \\      break;
+        \\  }
+        \\}
     ;
 
     var lexer: patapim.Lexer = .{ .source = source };

--- a/src/parse/Parser.zig
+++ b/src/parse/Parser.zig
@@ -233,7 +233,7 @@ pub fn parseAnyStatement(self: *Self) Self.Error!usize {
     if (try self.parseMaybeStructDeclStatement()) |stmt| return stmt;
     if (try self.parseMaybeEnumDeclStatement()) |stmt| return stmt;
     if (try self.parseMaybeReturnStatement()) |stmt| return stmt;
-    if (try self.parseMaybeBreakStatement()) |stmt| return stmt;
+    if (try self.parseMaybeFlowControlment()) |stmt| return stmt;
     if (try self.parseMaybeContinueStatement()) |stmt| return stmt;
     // Temporary...
     if (try self.parseMaybeExpressionStatement()) |stmt| return stmt;
@@ -620,7 +620,7 @@ pub fn parseMaybeForLoop(self: *Self) !?usize {
 }
 
 // Parse maybe break statement and return its ID if parsed.
-pub fn parseMaybeBreakStatement(self: *Self) !?usize {
+pub fn parseMaybeFlowControlment(self: *Self) !?usize {
     if (try self.maybe(.KW_BREAK) == null) return null; // This may not be a break statement.
     try self.pushSpan();
     defer _ = self.popSpan();
@@ -1478,7 +1478,7 @@ test "Parse break statement" {
     var parser = Self.init(std.testing.allocator, &lexer);
     defer parser.deinit(true);
 
-    const break_id = (try parser.parseMaybeBreakStatement()).?;
+    const break_id = (try parser.parseMaybeFlowControlment()).?;
     const break_node = parser.tree.getNodeUnsafe(break_id);
 
     try std.testing.expectEqualDeep(ast.Node{

--- a/src/parse/Parser.zig
+++ b/src/parse/Parser.zig
@@ -233,7 +233,7 @@ pub fn parseAnyStatement(self: *Self) Self.Error!usize {
     if (try self.parseMaybeStructDeclStatement()) |stmt| return stmt;
     if (try self.parseMaybeEnumDeclStatement()) |stmt| return stmt;
     if (try self.parseMaybeReturnStatement()) |stmt| return stmt;
-    if (try self.parseMaybeFlowControlment()) |stmt| return stmt;
+    if (try self.parseMaybeBreakStatement()) |stmt| return stmt;
     if (try self.parseMaybeContinueStatement()) |stmt| return stmt;
     // Temporary...
     if (try self.parseMaybeExpressionStatement()) |stmt| return stmt;
@@ -620,7 +620,7 @@ pub fn parseMaybeForLoop(self: *Self) !?usize {
 }
 
 // Parse maybe break statement and return its ID if parsed.
-pub fn parseMaybeFlowControlment(self: *Self) !?usize {
+pub fn parseMaybeBreakStatement(self: *Self) !?usize {
     if (try self.maybe(.KW_BREAK) == null) return null; // This may not be a break statement.
     try self.pushSpan();
     defer _ = self.popSpan();
@@ -1579,7 +1579,7 @@ test "Parse break statement" {
     var parser = Self.init(std.testing.allocator, &lexer);
     defer parser.deinit(true);
 
-    const break_id = (try parser.parseMaybeFlowControlment()).?;
+    const break_id = (try parser.parseMaybeBreakStatement()).?;
     const break_node = parser.tree.getNodeUnsafe(break_id);
 
     try std.testing.expectEqualDeep(ast.Node{


### PR DESCRIPTION
Added support for while and loop type loops in interpreter
Also, interpreter supports break and continue statements for this loops

the interpterer supports statements like : 
 brr i = 0;
while(i<10){
i = i+1;
}
brr j = 2;
brr even = 0;
loop
{
loop
{
    j = j +1;
  if(j >= 10)
  {
      break;
  }
  }
even = even + 1;
 if(even == 15)
 {
     break;
  }
  }
also included test in main 