### PR TITLE
Accept newlines at the end of source + pretty print break and continue + read source in main from file

### DIFF
--- a/src/Lexer.zig
+++ b/src/Lexer.zig
@@ -199,6 +199,18 @@ fn reportError(self: *Self, code: []const u8, message: []const u8, error_type: S
     return error_type;
 }
 
+// Initialize the lexer with source code and its ID.
+pub fn isAtEndOrOnlyWhitespaceRemaining(self: *Self) bool {
+    var i = self.current;
+    while (i < self.source.len) {
+        switch (self.source[i]) {
+            ' ', '\t', '\n', '\r' => i += 1,
+            else => return false,
+        }
+    }
+    return true;
+}
+
 // Check whether lexer has reached the end of source being scanned.
 pub inline fn isAtEnd(self: *Self) bool {
     return self.current >= self.source.len;

--- a/src/main.zig
+++ b/src/main.zig
@@ -48,49 +48,17 @@ pub fn main() !void {
     // ;
 
     // ---< Interpreter Test >---
-    const source =
-        \\brr abc = 2+2;
-        \\brr def = 2*2;
-        \\brr ghi = def - abc;
-        \\ghi = ghi + (1 * 0.5);
-        \\if(abc < def) {
-        \\    brr x = 1;
-        \\    abc = x;
-        \\} else if(2 > 3) {
-        \\    brr x = 2;
-        \\    abc = x;
-        \\} else {
-        \\    brr x = 3;
-        \\    abc = x;
-        \\}
-        \\
-        \\
-        \\brr xyz = if(abc == 3) 10 else 20;
-        \\const pol = abc + def + ghi + xyz;
-        \\brr i = 0;
-        \\while(i<10){
-        \\i = i+1;
-        \\}
-        \\brr j = 2;
-        \\brr even = 0;
-        \\loop
-        \\{
-        \\  loop
-        \\  {
-        \\      j = j +1;
-        \\      if(j >= 10)
-        \\       {
-        \\          break;
-        \\       }
-        \\  }
-        \\  even = even + 1;
-        \\  if(even == 15)
-        \\  {
-        \\      break;
-        \\  }
-        \\}
-        \\def += abc;
-    ;
+
+    // Open current directory
+    const cwd = std.fs.cwd();
+
+    // Open the source file
+    const file = try cwd.openFile("./src/test.brr", .{});
+    defer file.close();
+
+    // Read the file contents into a buffer
+    const source = try file.readToEndAlloc(allocator, 10_000); // 10 KB max
+    defer allocator.free(source);
 
     var lexer: patapim.Lexer = .{ .source = source };
     var parser = patapim.Parser.init(allocator, &lexer);

--- a/src/parse/Parser.zig
+++ b/src/parse/Parser.zig
@@ -199,7 +199,7 @@ pub fn parseWholeSource(self: *Self) !usize {
     try self.pushSpanOnNextToken();
     defer _ = self.popSpan(); // We do not need to keep this span on stack after error.
 
-    while (!self.lexer.isAtEnd()) {
+    while (!self.lexer.isAtEndOrOnlyWhitespaceRemaining()) {
         const stmt = try self.parseAnyStatement();
         try module_statements.append(stmt);
     }

--- a/src/test.brr
+++ b/src/test.brr
@@ -1,0 +1,54 @@
+brr abc = 2+2;
+brr def = 2*2;
+brr ghi = def - abc;
+
+ghi = ghi + (1 * 0.5);
+
+if(abc < def) {
+    brr x = 1;
+    abc = x;
+} else if(2 > 3) {
+    brr x = 2;
+    abc = x;
+} else {
+    brr x = 3;
+    abc = x;
+}
+
+brr xyz = if(abc == 3) 10 else 20;
+const pol = abc + def + ghi + xyz;
+brr i = 0;
+
+while(i < 10){
+  i = i + 1;
+}
+
+brr j = 2;
+brr even = 0;
+
+loop
+{
+  loop
+  {
+      j = j + 1;
+      if(j >= 10)
+      {
+          break;
+      }
+  }
+
+  even = even + 1;
+
+  if(even == 15)
+  {
+      break;
+  }
+}
+
+def += abc;
+
+
+
+
+
+

--- a/src/utility/AstPrettyPrinter.zig
+++ b/src/utility/AstPrettyPrinter.zig
@@ -536,3 +536,31 @@ pub fn visitFieldDef(self: *Self, tree: *const ast.Tree, span: common.Span, def:
     try self.writer.writeAll(": ");
     try self.accept(tree, def.value);
 }
+
+pub fn visitBreakStmt(self: *Self, tree: *const ast.Tree, span: common.Span, break_stmt: void, visitee: anytype) !void {
+    _ = visitee;
+    _ = tree;
+    _ = break_stmt;
+
+    try self.writeIndent();
+    try self.writer.print("{}break{}", .{
+        ansi.Style{ .foreground = .{ .basic = .yellow } },
+        ansi.Style{ .modifiers = .{ .reset = true } },
+    });
+    try self.writeSpan(span);
+    try self.writer.writeByte('\n');
+}
+
+pub fn visitContinueStmt(self: *Self, tree: *const ast.Tree, span: common.Span, continue_stmt: void, visitee: anytype) !void {
+    _ = visitee;
+    _ = tree;
+    _ = continue_stmt;
+
+    try self.writeIndent();
+    try self.writer.print("{}continue{}", .{
+        ansi.Style{ .foreground = .{ .basic = .yellow } },
+        ansi.Style{ .modifiers = .{ .reset = true } },
+    });
+    try self.writeSpan(span);
+    try self.writer.writeByte('\n');
+}


### PR DESCRIPTION
### Description

- Allow trailing newlines at the end of the source without breaking parsing
- Improve debug output by pretty-printing `break` and `continue` nodes
- Read source code from `test.brr` file in `main.zig` instead of hardcoded string