### PR TITLE
Add tuples evaluation

### DIFF
--- a/spec/examples/nativeLib.zig
+++ b/spec/examples/nativeLib.zig
@@ -1,4 +1,4 @@
-// This is a Zig file that defines a native library for runtime values and a Fibonacci function.
+// This is a Zig file that defines a native library for runtime values and an add function.
 // You can make your own native functions by defining them in this way.
 const std = @import("std");
 

--- a/src/interpreter/Interpreter.zig
+++ b/src/interpreter/Interpreter.zig
@@ -11,7 +11,7 @@ source_id: []const u8,
 allocator: std.mem.Allocator,
 tree: *const ast.Tree,
 global_env: runtime.Environment,
-func_names_arena: std.heap.ArenaAllocator,
+mem_alloc_arena: std.heap.ArenaAllocator,
 
 // Diagnostics for logging errors.
 // These are untouched until the error occurs.
@@ -42,7 +42,7 @@ pub fn init(allocator: std.mem.Allocator, tree: *const ast.Tree, source_id: []co
         .global_env = global_environment,
         .diagnostic_arena = .init(allocator),
         .diagnostic_log = .init(allocator),
-        .func_names_arena = std.heap.ArenaAllocator.init(allocator),
+        .mem_alloc_arena = std.heap.ArenaAllocator.init(allocator),
     };
 }
 
@@ -54,7 +54,7 @@ pub fn deinit(self: *Self) void {
     self.diagnostic_log.deinit();
     self.diagnostic_arena.deinit();
     self.global_env.deinit();
-    self.func_names_arena.deinit();
+    self.mem_alloc_arena.deinit();
 }
 
 // Prints debug information about the interpreter's state.
@@ -219,7 +219,26 @@ pub fn evalNode(self: *Self, tree: *const ast.Tree, node_id: usize, env: *runtim
                         .ptr = intrinsics.arrayPush,
                     } };
                 }
+            } else if (target == .Tuple and member.kind == .integer_literal) {
+                if (member.kind.integer_literal > target.Tuple.len) {
+                    return self.reportError(
+                        "I013",
+                        "Tuple index out of bounds: {d}.",
+                        .{member.kind.integer_literal},
+                        error.IndexOutOfBounds,
+                        .{
+                            .labels = &.{.{
+                                .color = .{ .basic = .red },
+                                .span = node.span.asReportz(),
+                                .message = "Tuple index out of bounds.",
+                            }},
+                        },
+                    );
+                }
+
+                return target.Tuple[member.kind.integer_literal];
             }
+
             // temporary solution
             return self.reportError(
                 "I006",
@@ -286,6 +305,16 @@ pub fn evalNode(self: *Self, tree: *const ast.Tree, node_id: usize, env: *runtim
             );
             return value;
         },
+        .tuple => |tuple| {
+            const count = tuple.expressions.len;
+            const elements = try self.mem_alloc_arena.allocator().alloc(runtime.RuntimeValue, count);
+
+            for (tuple.expressions, 0..) |expr_id, i| {
+                elements[i] = try self.evalNode(tree, expr_id, env);
+            }
+
+            return runtime.RuntimeValue{ .Tuple = elements };
+        },
         .variable => |variable| {
             // Evaluate the variable declaration.
             const value = try self.evalNode(tree, variable.expression, env);
@@ -308,7 +337,7 @@ pub fn evalNode(self: *Self, tree: *const ast.Tree, node_id: usize, env: *runtim
             // Evaluate the function definition.
             const func_name = try self.getIdentifierName(tree, function_def.name);
 
-            const param_names = try self.func_names_arena.allocator().alloc([]const u8, function_def.parameters.len);
+            const param_names = try self.mem_alloc_arena.allocator().alloc([]const u8, function_def.parameters.len);
             for (function_def.parameters, 0..) |param, i| {
                 const param_node = tree.getNode(param).?;
                 const name = try self.getIdentifierName(tree, param_node.kind.parameter.name);
@@ -806,7 +835,7 @@ pub fn evalNativeFunctionDeclaration(self: *Self, tree: *const ast.Tree, node: a
         },
     );
 
-    const params = try self.func_names_arena.allocator().alloc(runtime.NativeFunctionValue.Arg, native_function_decl.parameters.len);
+    const params = try self.mem_alloc_arena.allocator().alloc(runtime.NativeFunctionValue.Arg, native_function_decl.parameters.len);
     for (native_function_decl.parameters, 0..) |param, i| {
         const param_node = tree.getNode(param).?;
         const name = try self.getIdentifierName(tree, param_node.kind.native_parameter.name);
@@ -819,7 +848,7 @@ pub fn evalNativeFunctionDeclaration(self: *Self, tree: *const ast.Tree, node: a
         .fn_ptr = fn_ptr,
     };
 
-    const fn_key = try std.fmt.allocPrint(self.func_names_arena.allocator(), "{s}/{}", .{ func_name, native_function_decl.parameters.len });
+    const fn_key = try std.fmt.allocPrint(self.mem_alloc_arena.allocator(), "{s}/{}", .{ func_name, native_function_decl.parameters.len });
 
     try env.define(fn_key, .{ .NativeFunction = native_function_value }, false);
     return .{ .NativeFunction = native_function_value };
@@ -888,6 +917,7 @@ pub fn evalFunctionCall(self: *Self, tree: *const ast.Tree, node: ast.Node, env:
                     .Function => .Function,
                     .NativeFunction => .Function,
                     .IntrinsicFunction => .Function,
+                    .Tuple => .Tuple,
                     .Void => .Unknown,
                 };
 

--- a/src/interpreter/runtime.zig
+++ b/src/interpreter/runtime.zig
@@ -18,6 +18,7 @@ pub const RuntimeValue = union(enum) {
     Boolean: bool,
     String: []const u8,
     Array: *std.ArrayList(RuntimeValue),
+    Tuple: []const RuntimeValue,
     Void: void,
     Function: FunctionValue,
     NativeFunction: NativeFunctionValue,
@@ -50,6 +51,21 @@ pub const RuntimeValue = union(enum) {
                         try string.append(']');
                     }
                 }
+                return string.toOwnedSlice();
+            },
+            .Tuple => |tuple| {
+                var string = std.ArrayList(u8).init(allocator);
+                defer string.deinit();
+
+                try string.append('(');
+                for (tuple, 0..) |el, i| {
+                    const s = try el.toString(allocator);
+                    defer allocator.free(s);
+
+                    try string.appendSlice(s);
+                    if (i != tuple.len - 1) try string.appendSlice(", ");
+                }
+                try string.append(')');
                 return string.toOwnedSlice();
             },
             .Void => allocator.dupe(u8, "void"),

--- a/src/parse/Parser.zig
+++ b/src/parse/Parser.zig
@@ -958,7 +958,17 @@ pub fn parsePostfix(self: *Self, operand: usize) Self.Error!usize {
             .DOT => {
                 _ = try self.expect(.DOT);
 
-                const member = try self.expectIdentifier();
+                // In case of tuple access, we can have a not standard accessor - number not an identifier.
+                const member = switch ((try self.peek()).type) {
+                    .INTEGER_LITERAL => blk: {
+                        const integer_token = try self.expect(.INTEGER_LITERAL);
+                        break :blk try self.tree.addNode(.{
+                            .span = integer_token.span,
+                            .kind = .{ .integer_literal = integer_token.literal.integer },
+                        });
+                    },
+                    else => try self.expectIdentifier(),
+                };
 
                 expr = try self.tree.addNode(.{
                     .span = self.peekSpan(),

--- a/src/parse/ast.zig
+++ b/src/parse/ast.zig
@@ -101,7 +101,7 @@ pub const Const = struct {
 };
 
 //Tuple structure, this is equivalent to the following code:
-//
+// `(expression1, expression2, ...)`
 pub const Tuple: type = struct {
     expressions: []const NodeId,
 };
@@ -313,5 +313,6 @@ pub const Type = enum {
     String,
     Function,
     Array,
+    Tuple,
     Unknown,
 };

--- a/src/test.brr
+++ b/src/test.brr
@@ -68,3 +68,7 @@ fn add(x, y) {
 }
 
 brr result = add(2, def-1);
+
+brr myTuple = (2+j, 3, "tuple", 4.5);
+
+ccc = myTuple.2;


### PR DESCRIPTION
## ✨ Features
**Tuple creation syntax:**
```
brr tuple = (1, 2, 3);
```
**Tuple element access by index:**
```
brr first = tuple.0;
```

🧠 Implementation details
- Accessing tuple elements via .<index> reuses the member access logic, treating numeric identifiers as tuple indices.
- Tuple-to-string conversion implemented for debugging and printing.