### PR TITLE
String concatenation

### DIFF
--- a/docs/syntax/operators.md
+++ b/docs/syntax/operators.md
@@ -60,3 +60,17 @@ Patapim provides a comprehensive set of operators for performing operations on v
 ()  Function call      (myFunction())
 ..  Range              (for i in 1..5)
 ```
+
+### 7. String Operators
+
+String concatenation ("hello" + "world" → "helloworld")
+
+**Behavior:**
+
+- Concatenates two strings when both operands are strings
+- Converts non-string operands (numbers) to strings automatically:
+  ```
+  "ID: " + 42;      // "ID: 42"
+  "Price: " + 92.12 // "Price: 92.12"
+  ```
+- Returns runtime error for incompatible types (e.g., array + string)

--- a/src/interpreter/Interpreter.zig
+++ b/src/interpreter/Interpreter.zig
@@ -620,7 +620,12 @@ pub fn evalBinaryExpr(self: *Self, tree: *const ast.Tree, node: ast.Node, env: *
                     .Float => |rf| break :blk .{ .Float = lf + rf },
                     else => return error.InvalidTypeForBinaryOperation,
                 },
-                // TODO: Implement string concatenation.
+                .String => |ls| switch (right_value) {
+                    .String => |rs| break :blk .{ .String = try std.mem.concat(self.mem_alloc_arena.allocator(), u8, &[_][]const u8{ ls, rs }) },
+                    .Integer => |ri| break :blk .{ .String = try std.fmt.allocPrint(self.mem_alloc_arena.allocator(), "{s}{d}", .{ ls, ri }) },
+                    .Float => |rf| break :blk .{ .String = try std.fmt.allocPrint(self.mem_alloc_arena.allocator(), "{s}{d}", .{ ls, rf }) },
+                    else => return error.InvalidTypeForBinaryOperation,
+                },
                 else => return error.InvalidTypeForBinaryOperation,
             }
         },


### PR DESCRIPTION
## Description

This PR implements **string concatenation** support for the language/interpreter, allowing expressions like:
- `"hello" + "world"` → `"helloworld"`
- `"abc" + 123` → `"abc123"`
- `"x" + 123.123` → `"x123.123"`

### Key Changes
1. **Type Handling**:
   - Strings can now be concatenated with other strings and numbers.
   - Non-string types (e.g., `int` or `float`) are auto-converted to strings (only if right-hand side)
   - Invalid operations (e.g., `array + string`) raise `InvalidTypeForBinaryOperation`.
  
2. **Syntax**:
   - Supports `+` operator for intuitive concatenation.

### Example Usage
```zig
// String + String
"foo" + "bar"  // "foobar"

// String + Number
"id:" + 42     // "id:42"
```